### PR TITLE
Fix publish task dependency

### DIFF
--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -101,6 +101,7 @@ class ReleasePlugin implements Plugin<Project> {
             assembleTask.dependsOn unityPack
             releaseTask.dependsOn assembleTask
             postReleaseTask.dependsOn publishTask
+            publishTask.mustRunAfter postReleaseTask
 
             githubPublishTask.onlyIf(new Spec<Task>() {
                 @Override


### PR DESCRIPTION
`publish` task must run after `release` task
`githubPublish` should not create the release tag before the release task tries to do so.