### PR TITLE
Bump net.wooga.paket version to 0.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     compile 'com.netflix.nebula:nebula-release-plugin:5.+'
     compile 'org.ajoberstar:gradle-git:1.7.+'
     compile 'cz.malohlava:visteg:1.0.+'
-    compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.6.1'
+    compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.7.0'
     compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.3.0'
 
     compile gradleApi()


### PR DESCRIPTION
This new version includes dedicated log output for all major
paket commands, and a new task `paketOutdated`