### PR TITLE
Set default release.scope to patch

### DIFF
--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -203,7 +203,9 @@ class ReleasePlugin implements Plugin<Project> {
 
             releaseExtension.with {
                 versionStrategy(WoogaStrategies.SNAPSHOT)
+                versionStrategy(WoogaStrategies.DEVELOPMENT)
                 versionStrategy(WoogaStrategies.PRE_RELEASE)
+                versionStrategy(WoogaStrategies.FINAL)
                 defaultVersionStrategy = NetflixOssStrategies.DEVELOPMENT
             }
         }

--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -232,12 +232,12 @@ class ReleasePluginSpec extends ProjectSpec {
 
         where:
         branchName          | expectedVersion
-        "master"            | "1.1.0-master00001"
-        "with/slash"        | "1.1.0-branchWithSlash00001"
-        "numbers0123456789" | "1.1.0-branchNumbersZeroOneTwoThreeFourFiveSixSevenEightNine00001"
-        "with/slash"        | "1.1.0-branchWithSlash00001"
-        "with_underscore"   | "1.1.0-branchWithUnderscore00001"
-        "with-dash"         | "1.1.0-branchWithDash00001"
+        "master"            | "1.0.1-master00001"
+        "with/slash"        | "1.0.1-branchWithSlash00001"
+        "numbers0123456789" | "1.0.1-branchNumbersZeroOneTwoThreeFourFiveSixSevenEightNine00001"
+        "with/slash"        | "1.0.1-branchWithSlash00001"
+        "with_underscore"   | "1.0.1-branchWithUnderscore00001"
+        "with-dash"         | "1.0.1-branchWithDash00001"
     }
 
     def createFile(String fileName, File directory) {


### PR DESCRIPTION
This will help during development when patch releases are created and
our integration counter is reseted.