### PR TITLE
Set github release isPrerelease as lazy value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     compile 'org.ajoberstar:gradle-git:1.7.+'
     compile 'cz.malohlava:visteg:1.0.+'
     compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.7.0'
-    compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.3.0'
+    compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.4.0'
 
     compile gradleApi()
     compile localGroovy()

--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -117,8 +117,9 @@ class ReleasePlugin implements Plugin<Project> {
 
             githubPublishTask.from(archives)
             githubPublishTask.dependsOn archives
-            githubPublishTask.tagName = "v${project.version}"
-            githubPublishTask.setReleaseName(project.version.toString())
+            githubPublishTask.setTagName({ project.version })
+            githubPublishTask.setReleaseName({ project.version.toString() })
+            githubPublishTask.setPrerelease({ project.status != 'release' })
         }
 
         configureVersionCode(project)


### PR DESCRIPTION
Description
-----------
Update dependency `net.wooga.atlas-github` to version `0.4.0` which
allows lazy property setting.
Set `isPrerelease` for github publish task only when `project.status` is
not `release`

Closes #7 

Changes
-------
* ![UPDATE] [`net.wooga.atlas-github`](https://github.com/wooga/atlas-github/releases/tag/v0.4.0) to version `0.4.0`
* ![IMPROVE] github publish task setup. Set `isPrerelease` property.

[NEW]:http://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
