### PR TITLE
Custom GitHub release body

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     compile 'org.ajoberstar:gradle-git:1.7.+'
     compile 'cz.malohlava:visteg:1.0.+'
     compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.7.0'
-    compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.3.0'
+    compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.5.0'
 
     compile gradleApi()
     compile localGroovy()

--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseBodyStrategy.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseBodyStrategy.groovy
@@ -1,0 +1,22 @@
+package wooga.gradle.release.utils
+
+import org.ajoberstar.gradle.git.release.base.ReleaseVersion
+import org.ajoberstar.grgit.Grgit
+import org.kohsuke.github.GHRepository
+import wooga.gradle.github.publish.PublishBodyStrategy
+
+class ReleaseBodyStrategy implements PublishBodyStrategy {
+
+    private Grgit git
+    private ReleaseVersion version
+
+    ReleaseBodyStrategy(ReleaseVersion version, Grgit git) {
+        this.git = git
+        this.version = version
+    }
+
+    @Override
+    String getBody(GHRepository repository) {
+        return new ReleaseNotesGenerator(git, repository).generateReleaseNotes(version)
+    }
+}

--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.release.utils
+
+import org.ajoberstar.gradle.git.release.base.ReleaseVersion
+import org.ajoberstar.grgit.Commit
+import org.ajoberstar.grgit.Grgit
+import org.kohsuke.github.GHPullRequest
+import org.kohsuke.github.GHRepository
+
+/**
+ * A generator class to create release notes from git log and pull request bodies.
+ */
+class ReleaseNotesGenerator {
+
+    public static final String INITAL_RELEASE_MSG = "* ![NEW] Initial Release\n"
+    public static final String ICON_IDS = """
+    <!-- START icon Id's -->
+        
+    [NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
+    [ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
+    [IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
+    [CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
+    [FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
+    [UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
+    
+    [BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
+    [REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
+    [IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
+    [ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
+    [WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
+    
+    <!-- END icon Id's -->
+    """.stripIndent()
+
+    private Grgit git
+    private GHRepository hub
+
+    ReleaseNotesGenerator(Grgit git, GHRepository hub) {
+        this.git = git
+        this.hub = hub
+    }
+
+    /**
+     * Generates a release note body message with given <code>version</code>.
+     * The generator will parse the git log from <code>HEAD</code> to previous version
+     * and reads change lists from referenced pull requests. If no pull requests commits
+     * can be found, it will list the git log.
+     * @param version The <code>ReleaseVersion</code> to create the release note for
+     * @return a <code>String</code> containing the generated release notes
+     */
+    String generateReleaseNotes(ReleaseVersion version) {
+        StringBuilder builder = new StringBuilder()
+        List<String> includes = ['HEAD']
+        List<String> excludes = createExcludes(version)
+
+        if (!version.previousVersion) {
+            builder << INITAL_RELEASE_MSG
+        }
+
+        List<Commit> log = git.log(includes: includes, excludes: excludes)
+        List<GHPullRequest> pullRequests = fetchPullRequestsFromLog(log)
+
+        List<String> changeList = []
+        pullRequests.inject(changeList) { ch, pr ->
+            def changes = pr.body.readLines().findAll { it.trim().startsWith("* ![") }
+            changes = changes.collect { it + " [#${pr.number}]" }
+            ch << changes.join("\n")
+        }
+
+        if (changeList.size() == 0) {
+            changeList << log.collect({ "* ${it.shortMessage}" }).join("\n")
+        }
+
+        changeList.removeAll([""])
+
+        if (changeList.size() > 0) {
+            builder << changeList.join("\n")
+            builder << "\n"
+            builder << ICON_IDS
+        }
+
+        builder.toString().trim()
+    }
+
+    protected List<GHPullRequest> fetchPullRequestsFromLog(List<Commit> log) {
+        String pattern = /#(\d+)/
+        def prCommits = log.findAll { it.shortMessage =~ pattern }
+        def prNumbers = prCommits.collect {
+            def m = (it.shortMessage =~ pattern)
+            m[0][1].toInteger()
+        }
+        def prs = prNumbers.collect { hub.getPullRequest(it) }
+        prs.removeAll([null])
+        prs
+    }
+
+    private List<String> createExcludes(ReleaseVersion version) {
+        List<String> excludes = []
+        if (version.previousVersion) {
+            String previousVersion = "v${version.previousVersion}^{commit}"
+            if (tagExists(previousVersion)) {
+                excludes << previousVersion
+            }
+        }
+        excludes
+    }
+
+    private boolean tagExists(String revStr) {
+        try {
+            git.resolve.toCommit(revStr)
+            return true
+        } catch (e) {
+            return false
+        }
+    }
+}

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
@@ -1,0 +1,84 @@
+package wooga.gradle.release.utils
+
+import org.ajoberstar.gradle.git.release.base.ReleaseVersion
+import org.ajoberstar.grgit.Grgit
+import org.kohsuke.github.GHPullRequest
+import org.kohsuke.github.GHRepository
+import spock.lang.Specification
+
+class ReleaseBodyStrategySpec extends Specification {
+
+    ReleaseBodyStrategy releaseBodyStrategy
+    Grgit git
+    GHRepository repository
+    ReleaseVersion version
+
+    def mockPullRequest(int number, Boolean changeSet = true) {
+        def bodyOut = new StringBuilder()
+
+        bodyOut << """
+        ## Description
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        """.stripIndent()
+
+        if(changeSet) {
+            bodyOut << """
+            ## Changes
+            * ![ADD] some stuff
+            * ![REMOVE] some stuff
+            * ![FIX] some stuff
+            
+            Yada Yada Yada Yada Yada
+            Yada Yada Yada Yada Yada
+            Yada Yada Yada Yada Yada
+            """.stripIndent()
+        }
+
+        def pr = Mock(GHPullRequest)
+        pr.body >> bodyOut.toString()
+        pr.number >> number
+        return pr
+    }
+
+    def setup() {
+        git = Grgit.init(dir: File.createTempDir())
+        git.commit(message: 'initial commit')
+
+        repository = Mock(GHRepository)
+        version = new ReleaseVersion("1.1.0", "1.0.0", false)
+
+        releaseBodyStrategy = new ReleaseBodyStrategy(version, git)
+    }
+
+    def "verify calls ReleaseNotesGenerator to generate release notes body"() {
+        given: "a git log with pull requests commits and tags"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+        git.tag.add(name: 'v1.0.0')
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#2)')
+        git.commit(message: 'commit (#3)')
+        git.commit(message: 'commit')
+
+        and: "mocked pull requests"
+        repository.getPullRequest(1) >> mockPullRequest(1)
+        repository.getPullRequest(2) >> mockPullRequest(2)
+        repository.getPullRequest(3) >> mockPullRequest(3)
+
+        when:
+        def body = releaseBodyStrategy.getBody(repository)
+
+        then:
+        body == ("""
+        * ![ADD] some stuff [#3]
+        * ![REMOVE] some stuff [#3]
+        * ![FIX] some stuff [#3]
+        * ![ADD] some stuff [#2]
+        * ![REMOVE] some stuff [#2]
+        * ![FIX] some stuff [#2]
+        """.stripIndent().stripMargin() + ReleaseNotesGenerator.ICON_IDS).trim()
+    }
+}

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -1,0 +1,243 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wooga.gradle.release.utils
+
+import org.ajoberstar.gradle.git.release.base.ReleaseVersion
+import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.service.TagService
+import org.kohsuke.github.GHPullRequest
+import org.kohsuke.github.GHRepository
+import spock.lang.Specification
+
+class ReleaseNotesGeneratorTest extends Specification {
+
+    Grgit git
+    TagService tag
+    GHRepository hub
+    ReleaseNotesGenerator releaseNoteGenerator
+
+    def setup() {
+        git = Grgit.init(dir: File.createTempDir())
+        git.commit(message: 'initial commit')
+
+        hub = Mock(GHRepository)
+
+        releaseNoteGenerator = new ReleaseNotesGenerator(git, hub)
+    }
+
+    def mockPullRequest(int number, Boolean changeSet = true) {
+        def bodyOut = new StringBuilder()
+
+        bodyOut << """
+        ## Description
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        Yada Yada Yada Yada Yada
+        """.stripIndent()
+
+        if(changeSet) {
+            bodyOut << """
+            ## Changes
+            * ![ADD] some stuff
+            * ![REMOVE] some stuff
+            * ![FIX] some stuff
+            
+            Yada Yada Yada Yada Yada
+            Yada Yada Yada Yada Yada
+            Yada Yada Yada Yada Yada
+            """.stripIndent()
+        }
+
+        def pr = Mock(GHPullRequest)
+        pr.body >> bodyOut.toString()
+        pr.number >> number
+        return pr
+    }
+
+    def "creates release notes from log and pull requests changes"() {
+        given: "a git log with pull requests commits and tags"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+        git.tag.add(name: 'v1.0.0')
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#2)')
+        git.commit(message: 'commit (#3)')
+        git.commit(message: 'commit')
+
+        and: "a version"
+        def version = new ReleaseVersion("1.1.0", "1.0.0", false)
+
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> mockPullRequest(1)
+        hub.getPullRequest(2) >> mockPullRequest(2)
+        hub.getPullRequest(3) >> mockPullRequest(3)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(version)
+
+        then:
+        notes == ("""
+        * ![ADD] some stuff [#3]
+        * ![REMOVE] some stuff [#3]
+        * ![FIX] some stuff [#3]
+        * ![ADD] some stuff [#2]
+        * ![REMOVE] some stuff [#2]
+        * ![FIX] some stuff [#2]
+        """.stripIndent().stripMargin() + ReleaseNotesGenerator.ICON_IDS).trim()
+    }
+
+    def "creates release notes with full log when previousVersion tag can't be found"() {
+        given: "a git log with pull requests commits"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#2)')
+        git.commit(message: 'commit (#3)')
+        git.commit(message: 'commit')
+
+        and: "a version"
+        def version = new ReleaseVersion("1.1.0", "1.0.0", false)
+
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> mockPullRequest(1)
+        hub.getPullRequest(2) >> mockPullRequest(2)
+        hub.getPullRequest(3) >> mockPullRequest(3)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(version)
+
+        then:
+        notes == ("""
+        * ![ADD] some stuff [#3]
+        * ![REMOVE] some stuff [#3]
+        * ![FIX] some stuff [#3]
+        * ![ADD] some stuff [#2]
+        * ![REMOVE] some stuff [#2]
+        * ![FIX] some stuff [#2]
+        * ![ADD] some stuff [#1]
+        * ![REMOVE] some stuff [#1]
+        * ![FIX] some stuff [#1]
+        """.stripIndent() + ReleaseNotesGenerator.ICON_IDS).trim()
+    }
+
+    def "skips pull requests it can't find"() {
+        given: "a git log with pull requests commits"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#2)')
+        git.commit(message: 'commit (#3)')
+        git.commit(message: 'commit')
+
+        and: "a version"
+        def version = new ReleaseVersion("1.1.0", "1.0.0", false)
+
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> mockPullRequest(1)
+        hub.getPullRequest(3) >> mockPullRequest(3)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(version)
+
+        then:
+        notes == ("""
+        * ![ADD] some stuff [#3]
+        * ![REMOVE] some stuff [#3]
+        * ![FIX] some stuff [#3]
+        * ![ADD] some stuff [#1]
+        * ![REMOVE] some stuff [#1]
+        * ![FIX] some stuff [#1]
+        """.stripIndent() + ReleaseNotesGenerator.ICON_IDS).trim()
+    }
+
+    def "creates initial change message when previosVersion is not set"() {
+        given: "a git log with pull requests commits and tags"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+
+        and: "a version"
+        def version = new ReleaseVersion("1.1.0", null, false)
+
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> mockPullRequest(1)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(version)
+
+        then:
+        notes == ("""
+        * ![NEW] Initial Release
+        * ![ADD] some stuff [#1]
+        * ![REMOVE] some stuff [#1]
+        * ![FIX] some stuff [#1]
+        """.stripIndent() + ReleaseNotesGenerator.ICON_IDS).trim()
+    }
+
+    def "prints commit log when pull requests are empty"() {
+        given: "a git log with pull requests commits and tags"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+        git.tag.add(name: 'v1.0.0')
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#2)')
+        git.commit(message: 'commit (#3)')
+        git.commit(message: 'commit')
+
+        and: "a version"
+        def version = new ReleaseVersion("1.1.0", "1.0.0", false)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(version)
+
+        then:
+        notes == ("""
+        * commit
+        * commit (#3)
+        * commit (#2)
+        * commit
+        """.stripIndent() + ReleaseNotesGenerator.ICON_IDS).trim()
+    }
+
+    def "creates empty notes when pull requests have no changeset list"() {
+        given: "a git log with pull requests commits"
+
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#1)')
+        git.commit(message: 'commit')
+        git.commit(message: 'commit (#2)')
+        git.commit(message: 'commit (#3)')
+        git.commit(message: 'commit')
+
+        and: "a version"
+        def version = new ReleaseVersion("1.1.0", "1.0.0", false)
+
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> mockPullRequest(1, false)
+        hub.getPullRequest(3) >> mockPullRequest(3, false)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(version)
+
+        then:
+        notes == ""
+    }
+}


### PR DESCRIPTION
This pull request adds helper logic to create nice default release notes.

Right after the release tag is created the github publish task will ask for the release body value. This value is provided via a custom `PublishBodyStrategy` implementation. 

```groovy
interface PublishBodyStrategy {
    String getBody(GHRepository repository)
}
```

This new class will take the provided `GHRepository` parameter in `getBody` together with the given `GrGit` and `ReleaseVersion` objects and feed it to the new utility class `ReleaseNotesGenerator`.

The `ReleaseNotesGenerator` will execute several steps to build the notes body string:

* retrieve a list of commits between the current and last version
* scan these commit messages for pull request merge commits. (maked with `#number`)
* read the `change list` for each pull request and append it to the body string.
* append `icon` url links

**example output**
```
* ![ADD] some stuff [#3]
* ![REMOVE] some stuff [#3]
* ![FIX] some stuff [#3]
* ![ADD] some stuff [#2]
* ![REMOVE] some stuff [#2]
* ![FIX] some stuff [#2]

<!-- START icon Id's -->
        
[NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
    
[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
    
<!-- END icon Id's -->
```
---
* ![ADD] some stuff [#3]
* ![REMOVE] some stuff [#3]
* ![FIX] some stuff [#3]
* ![ADD] some stuff [#2]
* ![REMOVE] some stuff [#2]
* ![FIX] some stuff [#2]

<!-- START icon Id's -->
        
[NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
    
[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
    
<!-- END icon Id's -->
---



There are more cases. Read the `ReleaseNotesGeneratorTest`. It covers all cases.
