### PR TITLE
Fix case when pull request can't be loaded

### DIFF
--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
@@ -104,7 +104,15 @@ class ReleaseNotesGenerator {
             def m = (it.shortMessage =~ pattern)
             m[0][1].toInteger()
         }
-        def prs = prNumbers.collect { hub.getPullRequest(it) }
+        def prs = prNumbers.collect {
+            def pm
+            try {
+                pm = hub.getPullRequest(it)
+            }
+            finally {
+                return pm
+            }
+        }
         prs.removeAll([null])
         prs
     }

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -35,7 +35,6 @@ class ReleaseNotesGeneratorTest extends Specification {
         git.commit(message: 'initial commit')
 
         hub = Mock(GHRepository)
-
         releaseNoteGenerator = new ReleaseNotesGenerator(git, hub)
     }
 
@@ -151,6 +150,7 @@ class ReleaseNotesGeneratorTest extends Specification {
 
         and: "mocked pull requests"
         hub.getPullRequest(1) >> mockPullRequest(1)
+        hub.getPullRequest(2) >> { throw new FileNotFoundException("missing") }
         hub.getPullRequest(3) >> mockPullRequest(3)
 
         when:
@@ -205,6 +205,11 @@ class ReleaseNotesGeneratorTest extends Specification {
         and: "a version"
         def version = new ReleaseVersion("1.1.0", "1.0.0", false)
 
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> { throw new FileNotFoundException("missing") }
+        hub.getPullRequest(2) >> { throw new FileNotFoundException("missing") }
+        hub.getPullRequest(3) >> { throw new FileNotFoundException("missing") }
+
         when:
         def notes = releaseNoteGenerator.generateReleaseNotes(version)
 
@@ -232,6 +237,7 @@ class ReleaseNotesGeneratorTest extends Specification {
 
         and: "mocked pull requests"
         hub.getPullRequest(1) >> mockPullRequest(1, false)
+        hub.getPullRequest(2) >> { throw new FileNotFoundException("missing") }
         hub.getPullRequest(3) >> mockPullRequest(3, false)
 
         when:


### PR DESCRIPTION
In the case of an exception during `getPullRequest` in
`fetchPullRequestsFromLog`, return null instead of crashing.