### PR TITLE
Normalize release note text after generation

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/release/GithubIntegration.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/GithubIntegration.groovy
@@ -63,6 +63,29 @@ abstract class GithubIntegration extends IntegrationSpec {
         releaseBuilder.create()
     }
 
+    def createClosedPullRequest(String name, String body, Boolean majorChange = true) {
+        final String branchName = "testBranch"
+        final String refName = "refs/heads/$branchName"
+
+        def ref = testRepo.createRef(refName, testRepo.getBranch("master").getSHA1())
+        testRepo.createContent("test file content", "test file", "Test.md", branchName)
+        def pr = testRepo.createPullRequest(name, branchName, "master", body)
+
+        if (majorChange) {
+            try {
+                testRepo.createLabel("Major Change", "000000")
+            }
+            catch (IOException exception) {
+            }
+
+            pr.setLabels("Major Change")
+        }
+
+        pr.close()
+        ref.delete()
+        pr
+    }
+
     def setupSpec() {
         client = GitHub.connectUsingOAuth(testUserToken)
         createTestRepo()
@@ -85,7 +108,7 @@ abstract class GithubIntegration extends IntegrationSpec {
                 it.delete()
             }
         }
-        catch(Error e) {
+        catch (Error e) {
 
         }
 

--- a/src/main/groovy/wooga/gradle/release/tasks/UpdateReleaseNotes.groovy
+++ b/src/main/groovy/wooga/gradle/release/tasks/UpdateReleaseNotes.groovy
@@ -62,12 +62,12 @@ class UpdateReleaseNotes extends AbstractGithubTask {
     protected update() {
         GHCommit lastCommit = ++repository.listCommits().iterator()
         GHContent content = repository.getFileContent(project.relativePath(getReleaseNotes()), lastCommit.getSHA1())
-
-        if (content.read().text == getReleaseNotes().text) {
+        def body = getReleaseNotes().text.normalize()
+        if (content.read().text == body) {
             logger.info("no content change in release notes")
             throw new StopActionException()
         }
 
-        content.update(getReleaseNotes().text, getCommitMessage())
+        content.update(body, getCommitMessage())
     }
 }

--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
@@ -91,7 +91,7 @@ class ReleaseNotesGenerator {
         MustacheFactory mf = new DefaultMustacheFactory()
         Mustache mustache = mf.compile("${template}.mustache")
         mustache.execute(writer, noteBodyModel).flush()
-        writer.toString()
+        writer.toString().normalize().denormalize()
     }
 
     protected ReleaseNoteBody releaseNoteBodyFromVersion(ReleaseVersion version) {


### PR DESCRIPTION
# Description

The body values for pull requests retrieved via the github API are not
normalized. The generator creates files in a mix line ending mode.
Together with the append method, which will push the changes directly to
github without any git `clean/smudge` settings applied, this leads to a
bad user expirience when pulling these changes.

# Changes

![FIX] normalize release note content

[NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
    
[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"