### PR TITLE
Fix base url for change set icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,5 +76,5 @@ limitations under the License.
 [paket]:            https://fsprojects.github.io/Paket/
 [nuget]:            https://www.nuget.org/
 
-[yes]:                  http://atlas-resources.wooga.com/icons/icon_check.svg "yes"
-[no]:                   http://atlas-resources.wooga.com/icons/icon_uncheck.svg "no"
+[yes]:                  https://atlas-resources.wooga.com/icons/icon_check.svg "yes"
+[no]:                   https://atlas-resources.wooga.com/icons/icon_uncheck.svg "no"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,17 +6,17 @@
 
 <!-- START icon Id's -->
 
-[NEW]:http://atlas-resources.wooga.com/icons/icon_new.svg "New"
-[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
-[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
-[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
-[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
-[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"
+[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
+[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
+[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
+[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
+[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
+[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"
 
-[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
-[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
-[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
-[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
-[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
+[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Break"
+[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
+[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
+[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
+[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
 
 <!-- END icon Id's -->

--- a/src/main/resources/iconlist.mustache
+++ b/src/main/resources/iconlist.mustache
@@ -1,16 +1,16 @@
 <!-- START icon Id's -->
 
-[NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
-[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
-[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
-[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
-[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
-[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
+[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
+[ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
+[IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
+[CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
+[FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
+[UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"
 
-[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
-[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
-[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
-[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
-[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
+[BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
+[REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
+[IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
+[ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
+[WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
 
 <!-- END icon Id's -->

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -33,18 +33,18 @@ class ReleaseNotesGeneratorTest extends Specification {
     public static final String ICON_IDS = """
     <!-- START icon Id's -->
         
-    [NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
-    [ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
-    [IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
-    [CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
-    [FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
-    [UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
+    [NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
+    [ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
+    [IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
+    [CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
+    [FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
+    [UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"
     
-    [BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
-    [REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
-    [IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
-    [ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
-    [WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
+    [BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
+    [REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
+    [IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
+    [ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
+    [WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
     
     <!-- END icon Id's -->
     """.stripIndent()


### PR DESCRIPTION
## Description
Use proper `https` URL to change set icons

## Changes

* ![FIX] changeset icon base URL `resources.atlas` -> `atlas-resources`
* ![FIX] changeset icon URL protocol to `https`

[NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
