### PR TITLE
Cleanup multiple changeset icon links

### DIFF
--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNoteBody.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNoteBody.groovy
@@ -48,7 +48,7 @@ class ReleaseNoteBody {
 
         String cleanupBody(String body) {
             body.replaceAll("(?m)^#", "###")
-                    .replaceAll(/\[.*?\]:http:\/\/resources.atlas.wooga.com\/icons\/.*/, "")
+                    .replaceAll(/\[.*?\]:http(s)?:\/\/((resources\.)?atlas(-resources)?)\.wooga\.com\/icons.*/, "")
                     .replaceAll(/(?m)<!--.*?-->/, "")
                     .trim()
         }

--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNoteBody.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNoteBody.groovy
@@ -46,10 +46,17 @@ class ReleaseNoteBody {
 
         List<ChangeNote> changeList
 
+        String cleanupBody(String body) {
+            body.replaceAll("(?m)^#", "###")
+                    .replaceAll(/\[.*?\]:http:\/\/resources.atlas.wooga.com\/icons\/.*/, "")
+                    .replaceAll(/(?m)<!--.*?-->/, "")
+                    .trim()
+        }
+
         PullRequest(GHPullRequest pr) {
             title = pr.title
             issueUrl = "https://github.com/${pr.repository.fullName}/pull/${pr.number}"
-            body = pr.body.replaceAll("(?m)^#", "###").trim()
+            body = cleanupBody(pr.body)
             number = pr.number
             labels = pr.labels
 

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -91,7 +91,8 @@ class ReleaseNotesGeneratorTest extends Specification {
             Yada Yada Yada Yada Yada
             Yada Yada Yada Yada Yada
             Yada Yada Yada Yada Yada
-            """.stripIndent()
+
+            """.stripIndent() << ICON_IDS
         }
 
         def pr = Mock(GHPullRequest)

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -25,7 +25,6 @@ import org.kohsuke.github.GHPullRequest
 import org.kohsuke.github.GHRelease
 import org.kohsuke.github.GHRepository
 import org.kohsuke.github.PagedIterable
-import org.kohsuke.github.PagedIterator
 import spock.lang.Specification
 
 class ReleaseNotesGeneratorTest extends Specification {
@@ -48,6 +47,19 @@ class ReleaseNotesGeneratorTest extends Specification {
     
     <!-- END icon Id's -->
     """.stripIndent()
+
+    public static final String MIX_URL_ICON_IDS = """
+    <!-- START icon Id's -->
+
+    [NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
+    [ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
+    [IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
+    [CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
+
+    <!-- END icon Id's -->
+    """.stripIndent()
+
+
 
     Grgit git
     TagService tag
@@ -92,7 +104,7 @@ class ReleaseNotesGeneratorTest extends Specification {
             Yada Yada Yada Yada Yada
             Yada Yada Yada Yada Yada
 
-            """.stripIndent() << ICON_IDS
+            """.stripIndent() << MIX_URL_ICON_IDS
         }
 
         def pr = Mock(GHPullRequest)


### PR DESCRIPTION
## Description

Strip changeset icon url links from pull request bodies along with html
comments and whitespaces

## Changes

* ![FIX] duplicate changeset icon links in generated notes

[NEW]:http://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"
    
[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"