### PR TITLE
Add paket dependencies to release notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .gradle
 build/
+out/**
+.idea/**
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -13,3 +15,4 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 userHome/
+

--- a/src/integrationTest/groovy/wooga/gradle/release/GithubIntegration.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/GithubIntegration.groovy
@@ -55,8 +55,8 @@ abstract class GithubIntegration extends IntegrationSpec {
         testRepo = builder.create()
     }
 
-    def createRelease(String name) {
-        def releaseBuilder = testRepo.createRelease(name)
+    def createRelease(String name, String tagName = null) {
+        def releaseBuilder = testRepo.createRelease(tagName ? tagName : name)
         releaseBuilder.name(name)
         releaseBuilder.draft(false)
         releaseBuilder.prerelease(false)

--- a/src/integrationTest/groovy/wooga/gradle/release/ReleaseNotesGenerationIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/ReleaseNotesGenerationIntegrationSpec.groovy
@@ -1,6 +1,8 @@
 package wooga.gradle.release
 
 import org.ajoberstar.grgit.Grgit
+import wooga.gradle.release.utils.ReleaseNotesGeneratorTest
+import wooga.gradle.release.utils.TestContent
 
 class ReleaseNotesGenerationIntegrationSpec extends GithubIntegrationWithDefaultAuth {
 
@@ -224,5 +226,24 @@ class ReleaseNotesGenerationIntegrationSpec extends GithubIntegrationWithDefault
 
         then:
         releaseNotes.text.normalize().denormalize() == releaseNotes.text
+    }
+
+    def "generate releases with different paket.template files"(){
+
+        def paketTemplateFile = createFile("paket.template")
+        paketTemplateFile << TestContent.PAKET_TEMPLATE_V1
+
+        and: "some pull requests"
+        def prBody = """
+        ## Description
+        A small test of a pullrequest
+                
+        ## Changes
+        * ![ADD] some stuff
+        * ![REMOVE] some stuff
+        * ![FIX] some stuff
+        """.stripIndent().normalize().readLines().join("\r\n")
+
+        def pr1 = createClosedPullRequest("test pm", prBody)
     }
 }

--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNoteBody.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNoteBody.groovy
@@ -91,11 +91,13 @@ class ReleaseNoteBody {
     String packageId
     GHRepository repo
 
+    List<PacketDependency> dependencies
+
     ChangeNote initialChange = new ChangeNote("NEW", "Initial Release")
 
     boolean hasPreviousVersion
 
-    ReleaseNoteBody(ReleaseVersion version, Date releaseDate, String packageId, GHRepository repo, List<Commit> logs, List<GHPullRequest> prs, List<GHAsset> releaseAssets) {
+    ReleaseNoteBody(ReleaseVersion version, Date releaseDate, String packageId, GHRepository repo, List<Commit> logs, List<GHPullRequest> prs, List<GHAsset> releaseAssets, List<PacketDependency> dependencies) {
         this.logs = logs
         this.repo = repo
         this.hasPreviousVersion = version.previousVersion != null
@@ -107,6 +109,7 @@ class ReleaseNoteBody {
             new PullRequest(it)
         }
         this.releaseAssets = releaseAssets.toSorted({ a, b -> a.name <=> b.name })
+        this.dependencies = dependencies
     }
 
     Callable<List<PullRequest>> additionalChanges() {
@@ -159,6 +162,15 @@ class ReleaseNoteBody {
             @Override
             Boolean call() throws Exception {
                 return !releaseAssets.empty
+            }
+        }
+    }
+
+    Callable<Boolean> hasDependencies(){
+        new Callable<Boolean>() {
+            @Override
+            Boolean call() throws Exception {
+                !dependencies.empty
             }
         }
     }

--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
@@ -172,7 +172,7 @@ class ReleaseNotesGenerator {
 
     private List<PacketDependency> fetchTemplateDependencies(GHRepository hub, String packageId, ReleaseVersion version) {
 
-        String[] paths = ["$packageId/paket.template", "paket.template"]
+        List<String> paths = ["$packageId/paket.template", "paket.template"]
         String content
 
         paths.each {
@@ -192,11 +192,10 @@ class ReleaseNotesGenerator {
 
     private String GetTemplateContent(GHRepository hub, String path, ReleaseVersion version) {
         try {
-            def content = hub.getFileContent(path, "v$version.version").read().text
-            return content
+            return hub.getFileContent(path, "v$version.version").read().text
         }
         catch (IOException exception) {
-            logger.error("could not find paket template file at $path $exception.message")
+            logger.info("could not find paket template file at $path $exception.message")
             return null
         }
     }

--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
@@ -192,7 +192,7 @@ class ReleaseNotesGenerator {
 
     private String GetTemplateContent(GHRepository hub, String path, ReleaseVersion version) {
         try {
-            def content = hub.getFileContent(path, "tags/v$version.version").read().text
+            def content = hub.getFileContent(path, "v$version.version").read().text
             return content
         }
         catch (IOException exception) {

--- a/src/main/resources/dependency.mustache
+++ b/src/main/resources/dependency.mustache
@@ -1,0 +1,1 @@
+{{packageId}} {{&version}}

--- a/src/main/resources/releaseNote.mustache
+++ b/src/main/resources/releaseNote.mustache
@@ -37,6 +37,7 @@
 {{#hasDependencies}}
 
 ## Dependencies ##
+
 ```bash
 {{#dependencies}}{{>dependency}}
 {{/dependencies}}

--- a/src/main/resources/releaseNote.mustache
+++ b/src/main/resources/releaseNote.mustache
@@ -34,6 +34,14 @@
 * [{{name}}]({{browserDownloadUrl}})
 {{/releaseAssets}}
 {{/hasReleaseAssets}}
+{{#hasDependencies}}
+
+## Dependencies ##
+```bash
+{{#dependencies}}{{>dependency}}
+{{/dependencies}}
+```
+{{/hasDependencies}}
 
 ## How to install ##
 

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
@@ -2,7 +2,10 @@ package wooga.gradle.release.utils
 
 import org.ajoberstar.gradle.git.release.base.ReleaseVersion
 import org.ajoberstar.grgit.Grgit
+import org.apache.tools.ant.filters.StringInputStream
+import org.kohsuke.github.GHContent
 import org.kohsuke.github.GHPullRequest
+import org.kohsuke.github.GHRef
 import org.kohsuke.github.GHRepository
 import spock.lang.Specification
 
@@ -51,6 +54,15 @@ class ReleaseBodyStrategySpec extends Specification {
         version = new ReleaseVersion("1.1.0", "1.0.0", false)
 
         releaseBodyStrategy = new ReleaseBodyStrategy(version, git)
+
+        GHContent ghContent = Mock()
+        ghContent.read() >> {new StringInputStream(ReleaseNotesGeneratorTest.PAKET_TEMPALTE)}
+
+        GHRef ref = Mock()
+
+        repository.getRef(_) >> ref
+
+        repository.getFileContent(_, _) >> ghContent
     }
 
     def "verify calls ReleaseNotesGenerator to generate release notes body"() {

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
@@ -59,9 +59,7 @@ class ReleaseBodyStrategySpec extends Specification {
         ghContent.read() >> {new StringInputStream(TestContent.PAKET_TEMPLATE_V1)}
 
         GHRef ref = Mock()
-
         repository.getRef(_) >> ref
-
         repository.getFileContent(_, _) >> ghContent
     }
 

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseBodyStrategySpec.groovy
@@ -56,7 +56,7 @@ class ReleaseBodyStrategySpec extends Specification {
         releaseBodyStrategy = new ReleaseBodyStrategy(version, git)
 
         GHContent ghContent = Mock()
-        ghContent.read() >> {new StringInputStream(ReleaseNotesGeneratorTest.PAKET_TEMPALTE)}
+        ghContent.read() >> {new StringInputStream(TestContent.PAKET_TEMPLATE_V1)}
 
         GHRef ref = Mock()
 
@@ -92,6 +92,6 @@ class ReleaseBodyStrategySpec extends Specification {
         * ![ADD] some stuff [#2]
         * ![REMOVE] some stuff [#2]
         * ![FIX] some stuff [#2]
-        """.stripIndent().stripMargin() + ReleaseNotesGeneratorTest.ICON_IDS).trim()
+        """.stripIndent().stripMargin() + TestContent.ICON_IDS).trim()
     }
 }

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -32,68 +32,6 @@ import spock.lang.Specification
 
 class ReleaseNotesGeneratorTest extends Specification {
 
-    public static final String ICON_IDS = """
-    <!-- START icon Id's -->
-        
-    [NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
-    [ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
-    [IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
-    [CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
-    [FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
-    [UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"
-    
-    [BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
-    [REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
-    [IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
-    [ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
-    [WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
-    
-    <!-- END icon Id's -->
-    """.stripIndent()
-
-    public static final String MIX_URL_ICON_IDS = """
-    <!-- START icon Id's -->
-
-    [NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
-    [ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
-    [IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
-    [CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
-
-    <!-- END icon Id's -->
-    """.stripIndent()
-
-    public static final String PAKET_TEMPALTE = """
-    type file
-    id Wooga.Test
-    owners Wooga
-    authors Wooga
-    projectUrl
-        https://github.com/wooga/wdk-unity-Test
-    iconUrl
-        http://wooga.github.io/wdk-unity-Test/img/logo.png
-    licenseUrl
-        https://github.com/wooga/wdk-unity-Test/blob/master/LICENSE.txt
-    requireLicenseAcceptance
-        false
-    copyright
-        Copyright 2017
-    tags
-        wdk
-    summary
-        Wooga Test SDK
-    description
-        Wooga Test SDK
-    files
-        Assets/Wooga/**/* ==> content
-        !../**/AssemblyInfo.cs
-        ../README.md ==> content
-    dependencies
-        Wooga.TestDependency1 ~> 0.1.0
-        Wooga.TestDependency2 = 0.7
-        Wooga.TestDependency3
-        Wooga.TestDependency4 master
-        Wooga.TestDependency4 > 1, <2
-    """.stripIndent().trim()
 
     Grgit git
     TagService tag
@@ -116,7 +54,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         hub.listReleases() >> iterable
 
         GHContent ghContent = Mock()
-        ghContent.read() >> {new StringInputStream(PAKET_TEMPALTE)}
+        ghContent.read() >> {new StringInputStream(TestContent.PAKET_TEMPLATE_V1)}
 
         GHRef ref = Mock()
 
@@ -148,7 +86,7 @@ class ReleaseNotesGeneratorTest extends Specification {
             Yada Yada Yada Yada Yada
             Yada Yada Yada Yada Yada
 
-            """.stripIndent() << MIX_URL_ICON_IDS
+            """.stripIndent() << TestContent.MIX_URL_ICON_IDS
         }
 
         def pr = Mock(GHPullRequest)
@@ -209,7 +147,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         * ![ADD] some stuff [#2]
         * ![REMOVE] some stuff [#2]
         * ![FIX] some stuff [#2]
-        """.stripIndent().stripMargin() + ICON_IDS).trim()
+        """.stripIndent().stripMargin() + TestContent.ICON_IDS).trim()
     }
 
     def "creates release notes with full log when previousVersion tag can't be found"() {
@@ -244,7 +182,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         * ![ADD] some stuff [#1]
         * ![REMOVE] some stuff [#1]
         * ![FIX] some stuff [#1]
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
     }
 
     def "skips pull requests it can't find"() {
@@ -276,7 +214,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         * ![ADD] some stuff [#1]
         * ![REMOVE] some stuff [#1]
         * ![FIX] some stuff [#1]
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
     }
 
     def "creates initial change message when previosVersion is not set"() {
@@ -300,7 +238,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         * ![ADD] some stuff [#1]
         * ![REMOVE] some stuff [#1]
         * ![FIX] some stuff [#1]
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
     }
 
     def "prints commit log when pull requests are empty"() {
@@ -330,7 +268,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         * [`${c3.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c3.id}) ${c3.shortMessage}
         * [`${c2.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c2.id}) ${c2.shortMessage}
         * [`${c1.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c1.id}) ${c1.shortMessage}
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
     }
 
     def "prints commit log when pull requests have no changeset list"() {
@@ -361,7 +299,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         * [`${c3.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c3.id}) ${c3.shortMessage}
         * [`${c2.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c2.id}) ${c2.shortMessage}
         * [`${c1.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c1.id}) ${c1.shortMessage}
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
     }
 
     def "creates full release notes for specific version"() {
@@ -438,7 +376,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         # latest build with release candidates
         nuget $packageId ~> 1 rc
         ```
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
 
         where:
         currentVersion = "1.1.0"
@@ -532,7 +470,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         # latest build with release candidates
         nuget $packageId ~> 1 rc
         ```
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
 
         where:
         currentVersion = "1.1.0"
@@ -638,7 +576,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         # latest build with release candidates
         nuget $packageId ~> 1 rc
         ```
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
 
         where:
         currentVersion = "1.1.0"
@@ -736,7 +674,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         # latest build with release candidates
         nuget $packageId ~> 1 rc
         ```
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
 
         where:
         currentVersion = "1.1.0"
@@ -795,7 +733,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         # latest build with release candidates
         nuget $packageId ~> 1 rc
         ```
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
 
         where:
         currentVersion = "1.1.0"
@@ -862,7 +800,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         # latest build with release candidates
         nuget $packageId ~> 1 rc
         ```
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
 
         where:
         currentVersion = "1.1.0"
@@ -955,7 +893,7 @@ class ReleaseNotesGeneratorTest extends Specification {
         # latest build with release candidates
         nuget Wooga.Test ~> 1 rc
         ```
-        """.stripIndent() + ICON_IDS).trim()
+        """.stripIndent() + TestContent.ICON_IDS).trim()
 
         where:
         versionA = new ReleaseVersion("1.1.0", "1.0.0", false)

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -19,9 +19,12 @@ package wooga.gradle.release.utils
 import org.ajoberstar.gradle.git.release.base.ReleaseVersion
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.service.TagService
+import org.apache.tools.ant.filters.StringInputStream
 import org.kohsuke.github.GHAsset
+import org.kohsuke.github.GHContent
 import org.kohsuke.github.GHLabel
 import org.kohsuke.github.GHPullRequest
+import org.kohsuke.github.GHRef
 import org.kohsuke.github.GHRelease
 import org.kohsuke.github.GHRepository
 import org.kohsuke.github.PagedIterable
@@ -59,7 +62,38 @@ class ReleaseNotesGeneratorTest extends Specification {
     <!-- END icon Id's -->
     """.stripIndent()
 
-
+    public static final String PAKET_TEMPALTE = """
+    type file
+    id Wooga.Test
+    owners Wooga
+    authors Wooga
+    projectUrl
+        https://github.com/wooga/wdk-unity-Test
+    iconUrl
+        http://wooga.github.io/wdk-unity-Test/img/logo.png
+    licenseUrl
+        https://github.com/wooga/wdk-unity-Test/blob/master/LICENSE.txt
+    requireLicenseAcceptance
+        false
+    copyright
+        Copyright 2017
+    tags
+        wdk
+    summary
+        Wooga Test SDK
+    description
+        Wooga Test SDK
+    files
+        Assets/Wooga/**/* ==> content
+        !../**/AssemblyInfo.cs
+        ../README.md ==> content
+    dependencies
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+    """.stripIndent().trim()
 
     Grgit git
     TagService tag
@@ -80,6 +114,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         hub = Mock(GHRepository)
         hub.fullName >> "wooga/TestRepo"
         hub.listReleases() >> iterable
+
+        GHContent ghContent = Mock()
+        ghContent.read() >> {new StringInputStream(PAKET_TEMPALTE)}
+
+        GHRef ref = Mock()
+
+        hub.getRef(_) >> ref
+
+        hub.getFileContent(_, _) >> ghContent
+
         releaseNoteGenerator = new ReleaseNotesGenerator(git, hub, packageId)
     }
 

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -416,6 +416,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         * [`#3`](https://github.com/wooga/TestRepo/pull/3) Pullrequest 3
         * [`#1`](https://github.com/wooga/TestRepo/pull/1) Pullrequest 1
 
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+
         ## How to install ##
         
         ```bash
@@ -499,6 +509,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         
         * [binary.obj](http://github_asset/binary.obj)
         * [sources.zip](http://github_asset/sources.zip)
+
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
 
         ## How to install ##
         
@@ -596,6 +616,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         * [`#3`](https://github.com/wooga/TestRepo/pull/3) Pullrequest 3
         * [`#1`](https://github.com/wooga/TestRepo/pull/1) Pullrequest 1
 
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+
         ## How to install ##
         
         ```bash
@@ -684,6 +714,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         Yada Yada Yada Yada Yada
         Yada Yada Yada Yada Yada
 
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+
         ## How to install ##
         
         ```bash
@@ -733,6 +773,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         * [`#2`](https://github.com/wooga/TestRepo/pull/2) Pullrequest 2
         * [`#1`](https://github.com/wooga/TestRepo/pull/1) Pullrequest 1
 
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+        
         ## How to install ##
         
         ```bash
@@ -790,8 +840,18 @@ class ReleaseNotesGeneratorTest extends Specification {
         * [`${c2.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c2.id}) ${c2.shortMessage}
         * [`${c1.abbreviatedId}`](https://github.com/wooga/TestRepo/commit/${c1.id}) ${c1.shortMessage}
 
-        ## How to install ##
+        ## Dependencies ##
         
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+
+        ## How to install ##
+
         ```bash
         # latest stable
         nuget $packageId ~> 1
@@ -844,6 +904,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         * [`#3`](https://github.com/wooga/TestRepo/pull/3) Pullrequest 3
         * [`#2`](https://github.com/wooga/TestRepo/pull/2) Pullrequest 2
                 
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+
         ## How to install ##
         
         ```bash
@@ -863,6 +933,16 @@ class ReleaseNotesGeneratorTest extends Specification {
         
         * [`#1`](https://github.com/wooga/TestRepo/pull/1) Pullrequest 1
         
+        ## Dependencies ##
+        
+        ```bash
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3 
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+        ```
+
         ## How to install ##
         
         ```bash

--- a/src/test/groovy/wooga/gradle/release/utils/TestContent.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/TestContent.groovy
@@ -91,8 +91,8 @@ class TestContent {
         !../**/AssemblyInfo.cs
         ../README.md ==> content
     dependencies
-        Wooga.TestDependency1 ~> 0.1.0
-        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency1 ~> 0.2.0
+        Wooga.TestDependency2 = 0.8
         Wooga.TestDependency3
         Wooga.TestDependency4 master
         Wooga.TestDependency4 > 1, <2

--- a/src/test/groovy/wooga/gradle/release/utils/TestContent.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/TestContent.groovy
@@ -1,0 +1,102 @@
+package wooga.gradle.release.utils;
+
+class TestContent {
+
+    public static final String ICON_IDS = """
+    <!-- START icon Id's -->
+
+    [NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
+    [ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
+    [IMPROVE]:https://atlas-resources.wooga.com/icons/icon_improve.svg "IMPROVE"
+    [CHANGE]:https://atlas-resources.wooga.com/icons/icon_change.svg "Change"
+    [FIX]:https://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
+    [UPDATE]:https://atlas-resources.wooga.com/icons/icon_update.svg "Update"
+
+    [BREAK]:https://atlas-resources.wooga.com/icons/icon_break.svg "Remove"
+    [REMOVE]:https://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
+    [IOS]:https://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
+    [ANDROID]:https://atlas-resources.wooga.com/icons/icon_android.svg "Android"
+    [WEBGL]:https://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
+
+    <!-- END icon Id's -->
+    """.stripIndent()
+
+    public static final String MIX_URL_ICON_IDS = """
+    <!-- START icon Id's -->
+
+    [NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
+    [ADD]:https://atlas-resources.wooga.com/icons/icon_add.svg "Add"
+    [IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
+    [CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
+
+    <!-- END icon Id's -->
+    """.stripIndent()
+
+    public static final String PAKET_TEMPLATE_V1 = """
+    type file
+    id Wooga.Services
+    owners Wooga
+    authors Wooga
+    projectUrl
+        https://github.com/wooga/wdk-unity-CoreServices
+    iconUrl
+        http://wooga.github.io/wdk-unity-CoreServices/img/logo.png
+    licenseUrl
+        https://github.com/wooga/wdk-unity-CoreServices/blob/master/LICENSE.txt
+    requireLicenseAcceptance
+        false
+    copyright
+        Copyright 2017
+    tags
+        wdk
+    summary
+        Wooga Internal Services SDK
+    description
+        Wooga Internal Services SDK
+    files
+        Assets/Wooga/**/* ==> content
+        !../**/AssemblyInfo.cs
+        ../README.md ==> content
+    dependencies
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+    """.stripIndent().trim()
+
+    public static final String PAKET_TEMPLATE_V2 = """
+    type file
+    id Wooga.Services
+    owners Wooga
+    authors Wooga
+    projectUrl
+        https://github.com/wooga/wdk-unity-CoreServices
+    iconUrl
+        http://wooga.github.io/wdk-unity-CoreServices/img/logo.png
+    licenseUrl
+        https://github.com/wooga/wdk-unity-CoreServices/blob/master/LICENSE.txt
+    requireLicenseAcceptance
+        false
+    copyright
+        Copyright 2017
+    tags
+        wdk
+    summary
+        Wooga Internal Services SDK
+    description
+        Wooga Internal Services SDK
+    files
+        Assets/Wooga/**/* ==> content
+        !../**/AssemblyInfo.cs
+        ../README.md ==> content
+    dependencies
+        Wooga.TestDependency1 ~> 0.1.0
+        Wooga.TestDependency2 = 0.7
+        Wooga.TestDependency3
+        Wooga.TestDependency4 master
+        Wooga.TestDependency4 > 1, <2
+    """.stripIndent().trim()
+
+
+}

--- a/src/test/groovy/wooga/gradle/release/utils/TestContent.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/TestContent.groovy
@@ -97,6 +97,4 @@ class TestContent {
         Wooga.TestDependency4 master
         Wooga.TestDependency4 > 1, <2
     """.stripIndent().trim()
-
-
 }


### PR DESCRIPTION
## Description

Adds dependencies with version defined in a `paket.template` file (if available) to each release block in generated release notes. Fixes #13 

**Example**

## Dependencies ##

```bash
Wooga.TestDependency1 ~> 0.2.0
Wooga.TestDependency2 = 0.8
Wooga.TestDependency3 
Wooga.TestDependency4 master
Wooga.TestDependency4 > 1, <2
```