### PR TITLE
Fix ReleaseNoteGenerator handle multiple hashsigns in commit message

### DIFF
--- a/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/ReleaseNotesGenerator.groovy
@@ -115,12 +115,15 @@ class ReleaseNotesGenerator {
     }
 
     protected List<GHPullRequest> fetchPullRequestsFromLog(List<Commit> log) {
-        String pattern = /#(\d+)/
+        String pattern = /#(\d+)+/
         def prCommits = log.findAll { it.shortMessage =~ pattern }
         def prNumbers = prCommits.collect {
             def m = (it.shortMessage =~ pattern)
-            m[0][1].toInteger()
-        }
+            m.collect {
+                it[1].toInteger()
+            }
+        }.flatten()
+
         def prs = prNumbers.collect {
             def pm
             try {

--- a/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
+++ b/src/test/groovy/wooga/gradle/release/utils/ReleaseNotesGeneratorTest.groovy
@@ -217,7 +217,37 @@ class ReleaseNotesGeneratorTest extends Specification {
         """.stripIndent() + TestContent.ICON_IDS).trim()
     }
 
-    def "creates initial change message when previosVersion is not set"() {
+    def "allows multiple hash signs in commit message"() {
+        given: "one commit with multiple hash signs"
+
+        git.commit(message: '#44 fixes (#1), (#2) and (#3)')
+
+        and: "a version"
+        def version = new ReleaseVersion("1.1.0", "1.0.0", false)
+
+        and: "mocked pull requests"
+        hub.getPullRequest(1) >> mockPullRequest(1)
+        hub.getPullRequest(2) >> mockPullRequest(2)
+        hub.getPullRequest(3) >> mockPullRequest(3)
+
+        when:
+        def notes = releaseNoteGenerator.generateReleaseNotes(version, ReleaseNotesGenerator.Template.githubRelease)
+
+        then:
+        notes.normalize() == ("""
+        * ![ADD] some stuff [#3]
+        * ![REMOVE] some stuff [#3]
+        * ![FIX] some stuff [#3]
+        * ![ADD] some stuff [#2]
+        * ![REMOVE] some stuff [#2]
+        * ![FIX] some stuff [#2]
+        * ![ADD] some stuff [#1]
+        * ![REMOVE] some stuff [#1]
+        * ![FIX] some stuff [#1]
+        """.stripIndent() + TestContent.ICON_IDS).trim()
+    }
+
+    def "creates initial change message when previousVersion is not set"() {
         given: "a git log with pull requests commits and tags"
 
         git.commit(message: 'commit')


### PR DESCRIPTION
## Description

To find all closed pull requests withing one release cycle, the
`ReleaseNotesGenerator` collected all commits with the pattern `#(\d+)`.
The problem are commit messages with multiple hash signs. This can
happen when developers mark issues within the message or a pullrequest
title. This change allows to mark multiple pull requests with one commit
message.

## Changes

* ![FIX] method `fetchPullRequestsFromLog` to allow multiple `#n` patterns in message

fixes #19 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"