### PR TITLE
Ensure release notes file on repository

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/release/ReleaseNotesUpdateIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/ReleaseNotesUpdateIntegrationSpec.groovy
@@ -92,6 +92,21 @@ class ReleaseNotesUpdateIntegrationSpec extends GithubIntegrationWithDefaultAuth
         initialContent = "# 1.0.0 - Test #"
     }
 
+    def "creates release notes file if it doesn't exist"() {
+        given: "a repo without a release notes file"
+
+        when:
+        runTasksSuccessfully("customUpdateNotes")
+
+        then:
+        def lastCommit = ++testRepo.listCommits().iterator()
+        lastCommit.getCommitShortInfo().getMessage() == "Update release notes"
+
+        where:
+        initialContent = "# 1.0.0 - Test #"
+
+    }
+
     @Unroll
     def "updates release note with message #commitMessageObject value set via #methodName"() {
         given: "release notes file on remote repo"


### PR DESCRIPTION
## Description

If a repository does not contain a release notes file
then create it when retrieving it from github fails.

## Changes

* ![FIX] ensure release notes file on update

fixes #18 

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"