### PR TITLE
Add configureable meta clean pattern

### DIFF
--- a/src/main/groovy/wooga/gradle/release/AtlasReleasePluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/release/AtlasReleasePluginExtension.groovy
@@ -1,0 +1,23 @@
+package wooga.gradle.release
+
+import org.gradle.api.Action
+import org.gradle.api.tasks.util.PatternFilterable
+import org.gradle.api.tasks.util.PatternSet
+import org.gradle.util.ConfigureUtil
+
+class AtlasReleasePluginExtension {
+
+    private PatternSet metaCleanPattern = new PatternSet()
+
+    PatternFilterable getMetaCleanPattern() {
+        this.metaCleanPattern
+    }
+
+    void metaCleanPattern(Action<PatternFilterable> action) {
+        action.execute(this.metaCleanPattern)
+    }
+
+    void metaCleanPattern(Closure configureClosure) {
+        metaCleanPattern(ConfigureUtil.configureUsing(configureClosure))
+    }
+}


### PR DESCRIPTION
## Description

Some packages might need to adjust the `cleanMetaFiles` file pattern
because they want to add meta files for folders or asset bundles
This pullrequest makes this filter configurable

**build.gradle**

```groovy
atlasRelease.metaCleanPattern {
    include("**/*.cs")
    include("**/*.json")
    exclude("**/*.dll.meta")
    exclude("**/keep/*.cs.meta")
    exclude("**/keep/*.json.meta")
    exclude("**/keep/.meta")
}
```

The old pattern is applied by default:

```groovy
extension.metaCleanPattern {
    include("**/*.meta")
    exclude("**/*.dll.meta")
    exclude("**/*.so.meta")
}
```

## Changes

![ADD] configurable metadata clean pattern

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"