### PR TITLE
Update plugin dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,38 +16,12 @@
  */
 
 plugins {
-    id 'groovy'
-    id 'idea'
-    id 'maven-publish'
-    id 'com.gradle.plugin-publish' version '0.9.7'
-    id 'nebula.release' version '5.0.0'
-    id 'jacoco'
-    id "com.github.kt3k.coveralls" version "2.8.1"
+    id 'net.wooga.plugins' version '0.1.1'
 }
 
 group 'net.wooga.gradle'
 description = 'Unity3D plugin for Gradle.'
 
-sourceSets {
-    integrationTest {
-        groovy {
-            compileClasspath += main.output + test.output
-            runtimeClasspath += main.output + test.output
-            srcDir file('src/integrationTest/groovy')
-        }
-        resources.srcDir 'src/integrationTest/resources'
-    }
-}
-
-configurations {
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom testRuntime
-}
-
-idea.module {
-    testSourceDirs += file('src/integrationTest/groovy')
-    scopes.TEST.plus += [configurations.integrationTestCompile]
-}
 
 pluginBundle {
     website = 'https://github.com/wooga/atlas-release'
@@ -63,20 +37,7 @@ pluginBundle {
     }
 }
 
-repositories {
-    jcenter()
-
-    maven {
-        url "https://plugins.gradle.org/m2/"
-    }
-}
-
 dependencies {
-    testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
-        exclude module: 'groovy-all'
-    }
-
-    testCompile 'com.netflix.nebula:nebula-test:latest.release'
     testCompile('org.jfrog.artifactory.client:artifactory-java-client-services:+') {
         exclude module: 'logback-classic'
     }
@@ -84,57 +45,10 @@ dependencies {
     testCompile 'gradle.plugin.net.wooga.gradle:atlas-unity:0.10.0'
 
     compile 'com.github.spullara.mustache.java:compiler:0.8.18'
-    compile 'com.netflix.nebula:nebula-release-plugin:5.+'
-    compile 'org.ajoberstar:gradle-git:1.7.+'
     compile 'cz.malohlava:visteg:1.0.+'
-    compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.8.1'
+    compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.10.0'
     compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.6.0'
 
     compile gradleApi()
     compile localGroovy()
 }
-
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
-        }
-    }
-}
-
-task integrationTest(type: Test) {
-    testClassesDir = sourceSets.integrationTest.output.classesDir
-    classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
-}
-
-check.dependsOn integrationTest
-integrationTest.mustRunAfter test
-
-tasks.withType(Test) {
-    reports.html.destination = file("${reporting.baseDir}/${name}")
-}
-
-jacocoTestReport {
-    reports {
-        xml.enabled = true
-        html.enabled = true
-    }
-
-    executionData(test)
-    executionData(integrationTest)
-}
-
-tasks.coveralls {
-    onlyIf {System.getenv("CI") && JavaVersion.current().isJava8Compatible()}
-}
-
-project.tasks.releaseCheck.dependsOn project.tasks.check
-project.tasks.release.dependsOn project.tasks.assemble
-
-project.tasks.final.dependsOn project.tasks.publishPlugins
-project.tasks.publishPlugins.mustRunAfter project.tasks.postRelease
-
-project.tasks.snapshot.dependsOn project.tasks.publishToMavenLocal
-
-project.tasks.publishToMavenLocal.mustRunAfter project.tasks.postRelease

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip


### PR DESCRIPTION
## Description

The `net.wooga.paket` plugin had some interesting changes. This pull
request applies the latest version of this plugin. The development
`build.gradle` switched to the `net.wooga.plugins` plugin as a base to
remove all the verbose integration tests setups.

## Changes

![UPDATE] `net.wooga.paket` to `0.10.0`
![ADD] new development base plugin `net.wooga.plugins`
![UPDATE] development gradle version to `4.0`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
