### PR TITLE
Fix error messages for rc builds

### DIFF
--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -182,7 +182,6 @@ class ReleasePluginSpec extends ProjectSpec {
         taskName << [
                 ReleasePlugin.UNTIY_PACK_TASK,
                 ReleasePlugin.SETUP_TASK,
-                ReleasePlugin.RC_TASK,
                 ReleasePlugin.TEST_TASK
         ]
     }


### PR DESCRIPTION
## Description

The `NebularRelease` plugin will provide slightly better error messages when using the official
cli tasks (final, candidate, snapshot, ...). Because of internal naming reasons it makes sense for us to use `rc` instead of `candidate`. All other resources are named with the
pattern (final, rc and snapshot). I used a custom task with the name `rc` which depends on
`candidate` but this will fall through the error check in `NebularRelease`. So instead we
now change the cli tasklist on the fly. If we find the `rc` taskname in the cli tasklist we remove it
and add `candidate` instead.

## Changes

![ADD] alias from task `rc` to `candidate`
![REMOVE] custom task `rc`
![IMPROVE] error messages for `rc` builds

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
