### PR TITLE
Restructure package layout and add groovy docs

### DIFF
--- a/docs/api/wooga/gradle/release/WoogaStrategies.html
+++ b/docs/api/wooga/gradle/release/WoogaStrategies.html
@@ -91,7 +91,7 @@ if (location.href.indexOf('is-external=true') == -1) {
 </div>
 <div class="contentContainer">
 <ul class="inheritance">
-<li><ul class="inheritance"></ul></li><li>wooga.gradle.release.WoogaStrategies
+<li><ul class="inheritance"></ul></li><li>wooga.gradle.release.utils.WoogaStrategies
 </ul>
 <div class="description">
     <ul class="blockList">

--- a/src/integrationTest/groovy/wooga/gradle/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/ReleasePluginIntegrationSpec.groovy
@@ -65,10 +65,10 @@ class ReleasePluginIntegrationSpec extends IntegrationSpec {
 
         where:
         tagVersion       | versionCode
-        '1.1.0'          | 10200
+        '1.1.0'          | 10101
         '2.10.99'        | 21100
-        '0.3.0'          | 400
-        '12.34.200'      | 123500
+        '0.3.0'          | 301
+        '12.34.200'      | 123601
         '1.1.0-rc0001'   | 10100
         '2.10.99-branch' | 21099
         '0.3.0-a0000'    | 300
@@ -99,10 +99,10 @@ class ReleasePluginIntegrationSpec extends IntegrationSpec {
 
         where:
         tagVersion       | versionCode
-        '1.1.0'          | 10200
+        '1.1.0'          | 10101
         '2.10.99'        | 21100
-        '0.3.0'          | 400
-        '12.34.200'      | 123500
+        '0.3.0'          | 301
+        '12.34.200'      | 123601
         '1.1.0-rc0001'   | 10100
         '2.10.99-branch' | 21099
         '0.3.0-a0000'    | 300

--- a/src/main/groovy/wooga/gradle/release/AtlasReleasePluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/release/AtlasReleasePluginExtension.groovy
@@ -9,34 +9,25 @@ import org.gradle.util.ConfigureUtil
  * Extension object for <code>net.wooga.release</code> plugin.
  * This extension allows to set further default configurations for the plugin.
  */
-class AtlasReleasePluginExtension {
-
-    private PatternSet metaCleanPattern = new PatternSet()
-
+interface AtlasReleasePluginExtension {
     /**
      *
      * @return a pattern
      * @see org.gradle.api.tasks.util.PatternFilterable
      */
-    PatternFilterable getMetaCleanPattern() {
-        this.metaCleanPattern
-    }
+    PatternFilterable getMetaCleanPattern()
 
     /**
      * Allows to configure the <code>metaCleanPattern</code> filter object with an <code>Action</code> object.
      * @param action an action object to use for configuring the <code>metaCleanPattern</code>
      * @see #metaCleanPattern
      */
-    void metaCleanPattern(Action<PatternFilterable> action) {
-        action.execute(this.metaCleanPattern)
-    }
+    void metaCleanPattern(Action<PatternFilterable> action)
 
     /**
      * Allows to configure the <code>metaCleanPattern</code> filter object with a <code>Closure</code> object.
      * @param configureClosure a closure object to use for configuring the <code>metaCleanPattern</code>
      * @see #metaCleanPattern
      */
-    void metaCleanPattern(Closure configureClosure) {
-        metaCleanPattern(ConfigureUtil.configureUsing(configureClosure))
-    }
+    void metaCleanPattern(Closure configureClosure)
 }

--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -26,14 +26,16 @@ import org.ajoberstar.gradle.git.release.base.ReleaseVersion
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.AppliedPlugin
 import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Delete
-import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.util.PatternFilterable
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import wooga.gradle.github.GithubPlugin
 import wooga.gradle.github.publish.GithubPublish
@@ -43,13 +45,29 @@ import wooga.gradle.paket.base.PaketBasePlugin
 import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.pack.tasks.PaketPack
 import wooga.gradle.paket.unity.PaketUnityPlugin
+import wooga.gradle.release.internal.DefaultAtlasReleasePluginExtension
 import wooga.gradle.release.utils.ProjectStatusTaskSpec
+import wooga.gradle.release.utils.WoogaStrategies
 import wooga.gradle.releaseNotesGenerator.ReleaseNotesGeneratorPlugin
 import wooga.gradle.releaseNotesGenerator.utils.ReleaseBodyStrategy
 
+/**
+ * A Wooga internal plugin to develop and publish Unity library packages.
+ * This plugin is very opinionated. It acts as an aggregation plugin which applies a series of helper plugins and
+ * configures them according to the wooga sdk {@code wdk} standard.
+ * <p>
+ * Example:
+ * <pre>
+ * {@code
+ *     plugins {
+ *         id "net.wooga.release" version "0.15.1"
+ *     }
+ * }
+ * </pre>
+ */
 class ReleasePlugin implements Plugin<Project> {
 
-    static Logger logger = Logging.getLogger(ReleasePlugin)
+    private static Logger logger = Logging.getLogger(ReleasePlugin)
 
     static final String ARCHIVES_CONFIGURATION = "archives"
     static final String UNTIY_PACK_TASK = "unityPack"
@@ -60,113 +78,182 @@ class ReleasePlugin implements Plugin<Project> {
     static final String GROUP = "Wooga"
     static final String EXTENSION_NAME = "atlasRelease"
 
-    TaskContainer tasks
-    Project project
-    AtlasReleasePluginExtension extension
-
     @Override
     void apply(Project project) {
-        this.project = project
-        this.tasks = project.tasks
-        this.extension = (AtlasReleasePluginExtension) project.extensions.create(EXTENSION_NAME, AtlasReleasePluginExtension)
+        def extension = project.extensions.create(EXTENSION_NAME, DefaultAtlasReleasePluginExtension)
 
-        //set default meta clean Pattern
-        extension.metaCleanPattern {
-            include("**/*.meta")
-            exclude("**/*.dll.meta")
-            exclude("**/*.so.meta")
-        }
-
-
-        applyRCtoCandidateAlias(project)
+        configureDefaultMetaCleanPattern(extension)
 
         applyNebularRelease(project)
+        applyRCtoCandidateAlias(project)
         applyVisteg(project)
         applyWoogaPlugins(project)
 
+        configureArchiveConfiguration(project)
+        createUnityPackTask(project)
+
+        ProjectType type = new ProjectType(project)
+        if (type.isRootProject) {
+            configureSetupTask(project)
+            configureReleaseLifecycle(project)
+            configureGithubPublishTask(project)
+            configurePaketPackTasks(project)
+            project.pluginManager.apply(ReleaseNotesGeneratorPlugin)
+        }
+
+        configureVersionCode(project)
+        configureUnityPackageIfPresent(project, extension)
+        configureSetupTaskIfUnityPluginPresent(project)
+        configurePaketConfigurationArtifacts(project)
+    }
+
+    private static void configureReleaseLifecycle(final Project project) {
+        def tasks = project.tasks
+        def setup = tasks.maybeCreate(SETUP_TASK)
+
+        //hook up into lifecycle
+        def checkTask = tasks.getByName(LifecycleBasePlugin.CHECK_TASK_NAME)
+        def assembleTask = tasks.getByName(LifecycleBasePlugin.ASSEMBLE_TASK_NAME)
+        def buildTask = tasks.getByName(LifecycleBasePlugin.BUILD_TASK_NAME)
+        def releaseTask = tasks.getByName('release')
+        def postReleaseTask = tasks.getByName(nebula.plugin.release.ReleasePlugin.POST_RELEASE_TASK_NAME)
+        def publishTask = tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+        def testTask = tasks.maybeCreate(TEST_TASK)
+        def unityPack = tasks.getByName(UNTIY_PACK_TASK)
+
+        testTask.dependsOn setup
+        checkTask.dependsOn(testTask)
+        buildTask.dependsOn setup
+        assembleTask.dependsOn unityPack
+        releaseTask.dependsOn assembleTask
+        postReleaseTask.dependsOn publishTask
+        publishTask.mustRunAfter releaseTask
+    }
+
+    private static Task configureSetupTask(final Project project) {
+        project.tasks.maybeCreate(SETUP_TASK).with {
+            dependsOn(PaketGetPlugin.INSTALL_TASK_NAME)
+            group = GROUP
+            setDescription("run project setup")
+        }
+    }
+
+    /**
+     * Configures all tasks of type {@link PaketPack}.
+     * <p>
+     * It sets the paket version on each task because version 0.8.0 of {@code net.wooga.paket-pack} changed the
+     * default behavior for picking the package version.
+     *
+     * @param project
+     * @link wooga.gradle.paket.pack.PaketPackPlugin
+     */
+    protected static void configurePaketPackTasks(Project project) {
+        def setup = project.tasks.maybeCreate(SETUP_TASK)
+        project.tasks.withType(PaketPack, new Action<PaketPack>() {
+            @Override
+            void execute(PaketPack paketPack) {
+                /**
+                 * Sets project version to all {@code PaketPack} tasks.
+                 * Version 0.8.0 changed the default behavior for picking the package version.
+                 * This is just a security measure.
+                 *
+                 * */
+                paketPack.version = { project.version }
+                paketPack.dependsOn setup
+            }
+        })
+    }
+
+    /**
+     * Configures the {@code GithubPublish} task.
+     * <p>
+     * The method fetches the {@code githubPublish} task and sets up the artifacts to publish.
+     * Configures the tasks based on the release {@code stage} ({@code candidate} builds == {@code prerelease}).
+     * It sets also the release notes with the help of {@link ReleaseBodyStrategy}.
+     *
+     * @param project
+     * @see GithubPublishPlugin
+     * @see ReleaseNotesGeneratorPlugin
+     */
+    protected static void configureGithubPublishTask(Project project) {
+        def tasks = project.tasks
+        def archives = project.configurations.maybeCreate(ARCHIVES_CONFIGURATION)
+        def releaseExtension = project.extensions.findByType(ReleasePluginExtension)
+
+        def githubPublishTask = tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME) as GithubPublish
+        githubPublishTask.onlyIf(new ProjectStatusTaskSpec('candidate', 'release'))
+        githubPublishTask.from(archives)
+        githubPublishTask.dependsOn archives
+        githubPublishTask.tagName = "v${project.version}"
+        githubPublishTask.setReleaseName(project.version.toString())
+        githubPublishTask.setPrerelease({ project.status != 'release' })
+
+        //infer the ReleaseVersion in the private class DelayedVersion to be able to access the `inferredVersion` property
+        //the release plugin sets this object as version to all projects
+        project.version.toString()
+        githubPublishTask.body(new ReleaseBodyStrategy(project.version.inferredVersion as ReleaseVersion, releaseExtension.grgit))
+    }
+
+    /**
+     * Creates and Configures the projects {@code archive} configuration.
+     * @param project
+     * @return
+     */
+    protected static Configuration configureArchiveConfiguration(Project project) {
         Configuration archives = project.configurations.maybeCreate(ARCHIVES_CONFIGURATION)
         archives.extendsFrom(project.configurations.getByName(PaketBasePlugin.PAKET_CONFIGURATION))
-        def unityPack = tasks.create(name: UNTIY_PACK_TASK, type: Copy, group: GROUP) {
+    }
+
+    /**
+     * Creates Unity Pack task.
+     * <p>
+     * Creates a {@link Copy} task which will copy all {@code .unitypackage} artifacts into the output directory.
+     *
+     * @param project
+     */
+    protected static void createUnityPackTask(Project project) {
+        Configuration archives = project.configurations.maybeCreate(ARCHIVES_CONFIGURATION)
+        project.tasks.create(UNTIY_PACK_TASK, Copy).with {
+            group = GROUP
             from(archives) {
                 include '**/*.unitypackage'
             }
             into "${project.buildDir}/outputs"
         }
-
-        ProjectType type = new ProjectType(project)
-
-        if (type.isRootProject) {
-            def setup = tasks.create(name: SETUP_TASK, dependsOn: PaketGetPlugin.INSTALL_TASK_NAME, group: GROUP, description: 'run project setup')
-
-            //hook up into lifecycle
-            def checkTask = tasks.getByName(LifecycleBasePlugin.CHECK_TASK_NAME)
-            def assembleTask = tasks.getByName(LifecycleBasePlugin.ASSEMBLE_TASK_NAME)
-            def buildTask = tasks.getByName(LifecycleBasePlugin.BUILD_TASK_NAME)
-            buildTask.dependsOn setup
-
-            tasks.withType(PaketPack, new Action<PaketPack>() {
-                @Override
-                void execute(PaketPack paketPack) {
-                    /**
-                     * Sets project version to all <code>PaketPack</code> tasks.
-                     * Version 0.8.0 changed the default behavior for picking the package version.
-                     * This is just a security measure.
-                     *
-                     * */
-                    paketPack.version = { project.version }
-                    paketPack.dependsOn setup
-                }
-            })
-
-            def releaseTask = tasks.getByName('release')
-            def postReleaseTask = tasks.getByName(nebula.plugin.release.ReleasePlugin.POST_RELEASE_TASK_NAME)
-            def publishTask = tasks.getByName(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
-            GithubPublish githubPublishTask = (GithubPublish) tasks.getByName(GithubPublishPlugin.PUBLISH_TASK_NAME)
-            def candiateTask = tasks.getByName(nebula.plugin.release.ReleasePlugin.CANDIDATE_TASK_NAME)
-            if (!tasks.hasProperty(TEST_TASK)) {
-                def test = tasks.create(name: TEST_TASK, dependsOn: setup)
-                checkTask.dependsOn test
-            }
-
-            assembleTask.dependsOn unityPack
-            releaseTask.dependsOn assembleTask
-            postReleaseTask.dependsOn publishTask
-            publishTask.mustRunAfter releaseTask
-
-            ReleasePluginExtension releaseExtension = project.extensions.findByType(ReleasePluginExtension)
-
-            githubPublishTask.onlyIf(new ProjectStatusTaskSpec('candidate', 'release'))
-            githubPublishTask.from(archives)
-            githubPublishTask.dependsOn archives
-            githubPublishTask.tagName = "v${project.version}"
-            githubPublishTask.setReleaseName(project.version.toString())
-            githubPublishTask.setPrerelease({ project.status != 'release' })
-            //infer the ReleaseVersion in the private class DelayedVersion to be able to access the `inferredVersion` property
-            //the release plugin sets this object as version to all projects
-            project.version.toString()
-            githubPublishTask.body(new ReleaseBodyStrategy(project.version.inferredVersion as ReleaseVersion, releaseExtension.grgit))
-
-            project.pluginManager.apply(ReleaseNotesGeneratorPlugin)
-        }
-
-        configureVersionCode(project)
-        configureUnityPackageIfPresent(project)
-        configureSetupTaskIfUnityPluginPresent(project)
-        configurePaketConfigurationArtifacts(project)
     }
 
     /**
-     * The <code>NebularRelease</code> plugin will provide slightly better error messages when using the official
+     * Configures default clean pattern for the to be exported Unity nuget packages.
+     * <p>
+     * By default we need to keep the {@code .meta} files for {@code .dll} and {@code .so} files.
+     * This value can be reconfigured at a later time.
+     * @param extension
+     */
+    protected static void configureDefaultMetaCleanPattern(AtlasReleasePluginExtension extension) {
+        extension.metaCleanPattern(new Action<PatternFilterable>() {
+            @Override
+            void execute(PatternFilterable pattern) {
+                pattern.with {
+                    include("**/*.meta")
+                    exclude("**/*.dll.meta")
+                    exclude("**/*.so.meta")
+                }
+            }
+        })
+    }
+
+    /**
+     * The {@code NebularRelease} plugin will provide slightly better error messages when using the official
      * cli tasks (final, candidate, snapshot, ...). Because of internal naming reasons it makes sense for us to use
-     * <code>rc</code> instead of <code>candidate</code>. All other resources are named with the
-     * pattern (final, rc and snapshot). I used a custom task with the name <code>rc</code> which depends on
-     * <code>candidate</code> but this will fall through the error check in <code>NebularRelease</code>. So instead we
-     * now change the cli tasklist on the fly. If we find the <code>rc</code> taskname in the cli tasklist we remove it
-     * and add <code>candidate</code> instead.
+     * {@code rc} instead of {@code candidate}. All other resources are named with the
+     * pattern (final, rc and snapshot). I used a custom task with the name {@code rc} which depends on
+     * {@code candidate} but this will fall through the error check in {@code NebularRelease}. So instead we
+     * now change the cli tasklist on the fly. If we find the {@code rc} taskname in the cli tasklist we remove it
+     * and add {@code candidate} instead.
      * @param project
      * @return
      */
-    private applyRCtoCandidateAlias(Project project) {
+    protected static void applyRCtoCandidateAlias(Project project) {
         List<String> cliTasks = project.rootProject.gradle.startParameter.taskNames
         if (cliTasks.contains(RC_TASK)) {
             cliTasks.remove(RC_TASK)
@@ -175,7 +262,40 @@ class ReleasePlugin implements Plugin<Project> {
         }
     }
 
-    def configureVersionCode(Project project) {
+    /**
+     * Creates a versioncode string used by Android sub-projects.
+     * <p>
+     * Android applications or libraries need a version string and version code value.
+     * This method creates the versioncode based on the current version and sets it as an external property to
+     * all sub-projects.
+     * <p>
+     * The version will be splitted into {@code Major},{@code Minor} and {@code Patch} components
+     * and multiplied by an offset value. {@code Minor} and {@code Patch} must be lower < 100 otherwise the versionCode
+     * is no longer readable.
+     * <ul>
+     *     <li> {@code} Major * 10000
+     *     <li> {@code} Minor * 100
+     *     <li> {@code} Patch
+     * These values will be added together to form a single integer value.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     *      String version = "3.1.0"
+     *      Integer versionCode = 301000
+     *
+     *      String version = "1.24.33"
+     *      Integer versionCode = 12433
+     *
+     *      //version overflow
+     *      String version = "22.2245.455"
+     *      Integer versionCode = 444955
+     * }
+     * </pre>
+     *
+     * @param project
+     */
+    protected static void configureVersionCode(Project project) {
         def version = project.version.toString()
         def versionMatch = version =~ /(\d+)\.(\d+)\.(\d+)/
         String versionMajor = versionMatch[0][1]
@@ -188,24 +308,35 @@ class ReleasePlugin implements Plugin<Project> {
         }
     }
 
-    private configureUnityPackageIfPresent(Project project) {
+    /**
+     * Configures {@code net.wooga.unity} plugin on subprojects if available.
+     * <p>
+     * Iterates through all sub-projects and looks for the {@code net.wooga.unity} plugin.
+     * When applied, sets a project dependency to the {@code unitypackage} configuration and adds
+     * a clean metadata task dependency to {@code paketPack}.
+     *
+     * @param project
+     * @param extension
+     */
+    protected static void configureUnityPackageIfPresent(Project project, AtlasReleasePluginExtension extension) {
         DependencyHandler dependencies = project.dependencies
         project.subprojects { sub ->
-            sub.afterEvaluate {
-                logger.info("check subproject {} for unity plugin", sub.name)
-                if (sub.plugins.hasPlugin("net.wooga.unity")) {
+            sub.pluginManager.withPlugin("net.wooga.unity", new Action<AppliedPlugin>() {
+                @Override
+                void execute(AppliedPlugin appliedPlugin) {
                     logger.info("subproject {} has unity plugin.", sub.name)
                     logger.info("configure dependencies {}", sub.path)
                     dependencies.add(ARCHIVES_CONFIGURATION, dependencies.project(path: sub.path, configuration: "unitypackage"))
                     logger.info("create cleanMetaFiles task")
 
-                    Delete cleanTask = (Delete) sub.tasks.create(name: CLEAN_META_FILES_TASK, type: Delete)
                     def files = project.fileTree(new File(sub.projectDir, 'Assets/'))
 
                     files.include(extension.metaCleanPattern.includes)
                     files.exclude(extension.metaCleanPattern.excludes)
 
-                    cleanTask.delete(files)
+                    def cleanTask = sub.tasks.create(CLEAN_META_FILES_TASK, Delete).with {
+                        delete(files)
+                    }
 
                     project.tasks.withType(PaketPack, new Action<PaketPack>() {
                         @Override
@@ -214,11 +345,11 @@ class ReleasePlugin implements Plugin<Project> {
                         }
                     })
                 }
-            }
+            })
         }
     }
 
-    private configureSetupTaskIfUnityPluginPresent(Project project) {
+    private static configureSetupTaskIfUnityPluginPresent(Project project) {
         def rootSetupTask = project.rootProject.tasks[SETUP_TASK]
         project.subprojects { sub ->
             sub.afterEvaluate {
@@ -234,7 +365,7 @@ class ReleasePlugin implements Plugin<Project> {
         }
     }
 
-    private configurePaketConfigurationArtifacts(Project project) {
+    private static configurePaketConfigurationArtifacts(Project project) {
         project.afterEvaluate {
             Configuration paketConfiguration = project.configurations.getByName(PaketBasePlugin.PAKET_CONFIGURATION)
             paketConfiguration.allArtifacts.each {
@@ -243,7 +374,12 @@ class ReleasePlugin implements Plugin<Project> {
         }
     }
 
-    private void applyVisteg(Project project) {
+    /**
+     * Applies {@code cz.malohlava.visteg}
+     *
+     * @param project
+     */
+    protected static void applyVisteg(Project project) {
         project.pluginManager.apply(VisTaskExecGraphPlugin)
         VisTegPluginExtension visTegPluginExtension = project.extensions.findByType(VisTegPluginExtension)
         visTegPluginExtension.with {
@@ -259,7 +395,17 @@ class ReleasePlugin implements Plugin<Project> {
         }
     }
 
-    private void applyNebularRelease(Project project) {
+    /**
+     * Applies and configures {@code nebula.release} plugins.
+     * <p>
+     * Nebular release is the base plugin which we borrow logic from.
+     * We take apply our own versioning strategy pattern to be compatible
+     * with <a href="https://fsprojects.github.io/Paket/">Paket</a> and <a href="https://www.nuget.org/">Nuget</a>.
+     *
+     * @param project
+     * @see WoogaStrategies
+     */
+    protected static void applyNebularRelease(Project project) {
         project.pluginManager.apply(nebula.plugin.release.ReleasePlugin)
         ProjectType type = new ProjectType(project)
 
@@ -271,12 +417,22 @@ class ReleasePlugin implements Plugin<Project> {
                 releaseExtension.versionStrategy(WoogaStrategies.DEVELOPMENT)
                 releaseExtension.versionStrategy(WoogaStrategies.PRE_RELEASE)
                 releaseExtension.versionStrategy(WoogaStrategies.FINAL)
-                releaseExtension.defaultVersionStrategy = NetflixOssStrategies.DEVELOPMENT
+                releaseExtension.defaultVersionStrategy = WoogaStrategies.DEVELOPMENT
             }
         }
     }
 
-    private void applyWoogaPlugins(Project project) {
+    /**
+     * Applies Wooga plugins.
+     * <p>
+     * <ul>
+     *     <li>net.wooga.github
+     *     <li>net.wooga.paket
+     *     <li>net.wooga.paket-unity
+     *
+     * @param project
+     */
+    protected static void applyWoogaPlugins(Project project) {
         project.pluginManager.apply(GithubPlugin)
         project.pluginManager.apply(PaketPlugin)
         project.pluginManager.apply(PaketUnityPlugin)

--- a/src/main/groovy/wooga/gradle/release/internal/DefaultAtlasReleasePluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/release/internal/DefaultAtlasReleasePluginExtension.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.release.internal
+
+import org.gradle.api.Action
+import org.gradle.api.tasks.util.PatternFilterable
+import org.gradle.api.tasks.util.PatternSet
+import org.gradle.util.ConfigureUtil
+import wooga.gradle.release.AtlasReleasePluginExtension
+
+class DefaultAtlasReleasePluginExtension implements AtlasReleasePluginExtension{
+    private PatternSet metaCleanPattern = new PatternSet()
+
+    /**
+     *
+     * @return a pattern
+     * @see org.gradle.api.tasks.util.PatternFilterable
+     */
+    PatternFilterable getMetaCleanPattern() {
+        this.metaCleanPattern
+    }
+
+    /**
+     * Allows to configure the <code>metaCleanPattern</code> filter object with an <code>Action</code> object.
+     * @param action an action object to use for configuring the <code>metaCleanPattern</code>
+     * @see #metaCleanPattern
+     */
+    void metaCleanPattern(Action<PatternFilterable> action) {
+        action.execute(this.metaCleanPattern)
+    }
+
+    /**
+     * Allows to configure the <code>metaCleanPattern</code> filter object with a <code>Closure</code> object.
+     * @param configureClosure a closure object to use for configuring the <code>metaCleanPattern</code>
+     * @see #metaCleanPattern
+     */
+    void metaCleanPattern(Closure configureClosure) {
+        metaCleanPattern(ConfigureUtil.configureUsing(configureClosure))
+    }
+}

--- a/src/main/groovy/wooga/gradle/release/utils/WoogaStrategies.groovy
+++ b/src/main/groovy/wooga/gradle/release/utils/WoogaStrategies.groovy
@@ -5,16 +5,17 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *       http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package wooga.gradle.release
+package wooga.gradle.release.utils
 
 import nebula.plugin.release.NetflixOssStrategies
 import org.ajoberstar.gradle.git.release.opinion.Strategies
@@ -27,6 +28,12 @@ import org.ajoberstar.gradle.git.release.semver.StrategyUtil
 import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.closure
 import static org.ajoberstar.gradle.git.release.semver.StrategyUtil.parseIntOrZero
 
+/**
+ * Set of {@code SemVerStrategy} properties to determine current version.
+ * <p>
+ * All strategies are base on <a href="https://github.com/nebula-plugins/nebula-release-plugin">Nebular Release</a> or
+ * it's super set <a href="https://github.com/ajoberstar/gradle-git">Gradle Git</a>.
+ */
 class WoogaStrategies {
 
     private static final scopes = StrategyUtil.one(
@@ -57,6 +64,42 @@ class WoogaStrategies {
         return state.copyWith(inferredPreRelease: currentPreIdents.join('.'))
     }
 
+    /**
+     * Returns a version strategy to be used for {@code pre-release}/{@code candidate} builds.
+     * <p>
+     * This strategy infers the release version by checking the nearest any release.
+     * If a {@code pre-release} with the same {@code major}.{@code minor}.{@code patch} version exists, bumps the count part.
+     * <p>
+     * Example <i>new pre release</i>:
+     * <pre>
+     * {@code
+     * releaseScope = "minor"
+     * nearestVersion = "1.2.0"
+     * nearestAnyVersion = ""
+     * inferred = "1.3.0-rc00001"
+     * }
+     * </pre>
+     * <p>
+     * Example <i>pre release version exists</i>:
+     * <pre>
+     * {@code
+     * releaseScope = "minor"
+     * nearestVersion = "1.2.0"
+     * nearestAnyVersion = "1.3.0-rc00001"
+     * inferred = "1.3.0-rc00002"
+     * }
+     * </pre>
+     * <p>
+     * Example <i>last final release higher than pre-release</i>:
+     * <pre>
+     * {@code
+     * releaseScope = "minor"
+     * nearestVersion = "1.3.0"
+     * nearestAnyVersion = "1.3.0-rc00001"
+     * inferred = "1.4.0-rc00001"
+     * }
+     * </pre>
+     */
     static final SemVerStrategy PRE_RELEASE = Strategies.PRE_RELEASE.copyWith(
             normalStrategy: scopes,
             preReleaseStrategy: StrategyUtil.all(StrategyUtil.closure({ state ->
@@ -69,11 +112,77 @@ class WoogaStrategies {
             }))
     )
 
+    /**
+     * Returns a version strategy to be used for {@code final} builds.
+     * <p>
+     * This strategy infers the release version by checking the nearest release.
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     * releaseScope = "minor"
+     * nearestVersion = "1.3.0"
+     * inferred = "1.4.0"
+     * }
+     * </pre>
+     */
     static final SemVerStrategy FINAL = Strategies.FINAL.copyWith(normalStrategy: scopes)
+
+    /**
+     * Returns a version strategy to be used for {@code development} builds.
+     * <p>
+     * This strategy creates a unique version string based on last commit hash and the
+     * distance of commits to nearest normal version.
+     * This version string is not compatible with <a href="https://fsprojects.github.io/Paket/">Paket</a> or
+     * <a href="https://www.nuget.org/">Nuget</a>
+     * <p>
+     * Example:
+     * <pre>
+     * {@code
+     * releaseScope = "minor"
+     * nearestVersion = "1.3.0"
+     * commitHash = "90c90b9"
+     * distance = 22
+     * inferred = "1.3.0-dev.22+90c90b9"
+     * }
+     * </pre>
+     */
     static final SemVerStrategy DEVELOPMENT = Strategies.DEVELOPMENT.copyWith(
             normalStrategy: scopes,
             buildMetadataStrategy: NetflixOssStrategies.BuildMetadata.DEVELOPMENT_METADATA_STRATEGY)
 
+    /**
+     * Returns a version strategy to be used for {@code snapshot} builds.
+     * <p>
+     * This strategy creates a snapshot version suitable for <a href="https://fsprojects.github.io/Paket/">Paket</a> and
+     * <a href="https://www.nuget.org/">Nuget</a>. {@code Nuget} and {@code Paket} don't support
+     * {@code SNAPSHOT} versions or any numerical values after the {@code patch} component. We trick these package managers
+     * by creating a unique version based on {@code branch} and the distance of commits to nearest normal version.
+     * If the branch name contains numerical values, they will be converted into alphanumerical counterparts.
+     * The {@code master} branch is a special case so it will end up being higher than any other branch build (m>b)
+     * <p>
+     * Example <i>from master branch</i>:
+     * <pre>
+     * {@code
+     * releaseScope = "minor"
+     * nearestVersion = "1.3.0"
+     * branch = "master"
+     * distance = 22
+     * inferred = "1.4.0-master00022"
+     * }
+     * </pre>
+     * <p>
+     * Example <i>from topic branch</i>:
+     * <pre>
+     * {@code
+     * releaseScope = "minor"
+     * nearestVersion = "1.3.0"
+     * branch = "feature/fix_22"
+     * distance = 34
+     * inferred = "1.4.0-branchFeatureFixTwoTow00034"
+     * }
+     * </pre>
+     */
     static final SemVerStrategy SNAPSHOT = Strategies.PRE_RELEASE.copyWith(
             name: 'snapshot',
             stages: ['snapshot','SNAPSHOT'] as SortedSet,

--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -36,7 +36,7 @@ import wooga.gradle.github.publish.GithubPublishPlugin
 import wooga.gradle.paket.PaketPlugin
 import wooga.gradle.paket.pack.tasks.PaketPack
 import wooga.gradle.paket.unity.PaketUnityPlugin
-import wooga.gradle.release.WoogaStrategies
+import wooga.gradle.release.utils.WoogaStrategies
 
 
 class ReleasePluginActivationSpec extends PluginProjectSpec {
@@ -130,7 +130,7 @@ class ReleasePluginSpec extends ProjectSpec {
         def extension = project.extensions.findByType(org.ajoberstar.gradle.git.release.base.ReleasePluginExtension)
 
         expect:
-        extension.defaultVersionStrategy == NetflixOssStrategies.DEVELOPMENT
+        extension.defaultVersionStrategy == WoogaStrategies.DEVELOPMENT
     }
 
     def "add visteg plugin"() {


### PR DESCRIPTION
## Description

This pull requst update the package layout to have he same structural layout as all other `wooga` plugins. It also adds groovy documentation strings.

#29 

## Changes

![CHANGE] package structure
![ADD] groovydoc comments to public classes and methods

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
