### PR TITLE
Use paket restore during setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     compile 'org.ajoberstar:gradle-git:1.7.+'
     compile 'com.github.spullara.mustache.java:compiler:0.8.18'
     compile 'cz.malohlava:visteg:1.0.+'
-    compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.10.+'
+    compile 'gradle.plugin.net.wooga.gradle:atlas-paket:0.11.+'
     compile 'gradle.plugin.net.wooga.gradle:atlas-github:0.6.0'
     compile "gradle.plugin.net.wooga.gradle:atlas-releaseNotesGenerator:0.1.0"
 

--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -42,6 +42,7 @@ import wooga.gradle.github.publish.GithubPublish
 import wooga.gradle.github.publish.GithubPublishPlugin
 import wooga.gradle.paket.PaketPlugin
 import wooga.gradle.paket.base.PaketBasePlugin
+import wooga.gradle.paket.base.PaketPluginExtension
 import wooga.gradle.paket.get.PaketGetPlugin
 import wooga.gradle.paket.pack.tasks.PaketPack
 import wooga.gradle.paket.unity.PaketUnityPlugin
@@ -132,7 +133,9 @@ class ReleasePlugin implements Plugin<Project> {
 
     private static Task configureSetupTask(final Project project) {
         project.tasks.maybeCreate(SETUP_TASK).with {
-            dependsOn(PaketGetPlugin.INSTALL_TASK_NAME)
+            PaketPluginExtension paketPluginExtension = project.extensions.getByType(PaketPluginExtension);
+            def installTask = paketPluginExtension.getPaketLockFile().exists() ? PaketGetPlugin.RESTORE_TASK_NAME : PaketGetPlugin.INSTALL_TASK_NAME
+            dependsOn(installTask)
             group = GROUP
             setDescription("run project setup")
         }


### PR DESCRIPTION
## Description

For a more robust build setup we should switch to `paket restore` as the default dependency installation command. The command `paket install` could trigger changes if a dev changed the `paket.dependencies` file but not commting the `paket.lock` file. Alternativly the `paket restore`
command only installs dependencies listed in `paket.lock`. It even fails when no lock file exists. To counter this behavior, we will switch to `paket install` when no lock file is available.

resolves #36 

## Changes

![IMPROVE] paket dependency install step by using `paket restore` as default

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
