### PR TITLE
Fix branch push during release

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/release/ReleaseStepsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/ReleaseStepsIntegrationSpec.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.release
+
+import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.operation.BranchAddOp
+import org.gradle.internal.impldep.org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import spock.lang.Unroll
+
+class ReleaseStepsIntegrationSpec extends GithubIntegration {
+
+    Grgit git
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+
+    def setup() {
+        environmentVariables.set("GRGIT_USER", testUserName)
+        environmentVariables.set("GRGIT_PASS", testUserToken)
+
+        git = Grgit.init(dir: projectDir)
+
+        git.remote.add(name: "origin", url: "https://github.com/${testRepositoryName}.git")
+        git.commit(message: 'initial commit')
+        git.tag.add(name: "v0.1.0")
+    }
+
+    @Unroll
+    def "verify no branch push during release step #stage"() {
+        given: "a buildfile with release plugin applied"
+        createFile(".gitignore") << """
+        .gradle*/
+        build
+        """.stripIndent()
+        buildFile << """
+            ${applyPlugin(ReleasePlugin)}
+
+            github {
+                repositoryName = "${testRepositoryName}"
+            }
+        """.stripIndent()
+
+        createFile("RELEASE_NOTES.md")
+
+        and: "a new git branch"
+        git.checkout(branch: branchName, createBranch: true, startPoint: git.resolve.toRevisionString("master"))
+
+        and: "a last commit"
+        git.add(patterns: ["RELEASE_NOTES.md", "build.gradle", "settings.gradle", ".gitignore"])
+        git.commit(message: 'Add stuff', all: true)
+
+        when:
+        runTasksSuccessfully(stage, "-x", "updateReleaseNotes", "-x", "githubPublish")
+
+        then:
+        !testRepo.branches[branchName]
+
+        where:
+        stage       | branchName
+        "snapshot"  | "PR-22"
+        "rc"        | "release/1.x"
+        "candidate" | "release/1.x"
+        "final"     | "1.0.0"
+    }
+}


### PR DESCRIPTION
## Description

The `BaseReleasePlugin` will automatically push the current branch when the name != `HEAD`. This leads for us to some funny sideeffects on the Jenkins machines. This behavior is not configurable at this time. What this pull request does is override the `release` task action and provide a more conservative implementaton.

resolves #37 

### Issues

While implementing this I was wondering if we really want to stop every push or should make this somehow configurable on our side.

## Changes

![IMPROVE] `release` task. Remove `push` instruction.

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
