### PR TITLE
Update Nebular Release plugin dependency to 6.+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     testCompile 'gradle.plugin.net.wooga.gradle:atlas-unity:0.10.0'
     testCompile 'gradle.plugin.net.wooga.gradle:atlas-wdk-unity:0.1.0'
 
-    compile 'com.netflix.nebula:nebula-release-plugin:5.+'
+    compile 'com.netflix.nebula:nebula-release-plugin:6.+'
     compile 'org.ajoberstar:gradle-git:1.7.+'
     compile 'com.github.spullara.mustache.java:compiler:0.8.18'
     compile 'cz.malohlava:visteg:1.0.+'

--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -19,8 +19,6 @@ package wooga.gradle.release
 
 import cz.malohlava.VisTaskExecGraphPlugin
 import cz.malohlava.VisTegPluginExtension
-import nebula.core.ProjectType
-import nebula.plugin.release.NetflixOssStrategies
 import org.ajoberstar.gradle.git.release.base.BaseReleasePlugin
 import org.ajoberstar.gradle.git.release.base.ReleasePluginExtension
 import org.ajoberstar.gradle.git.release.base.ReleaseVersion
@@ -94,8 +92,7 @@ class ReleasePlugin implements Plugin<Project> {
         configureArchiveConfiguration(project)
         createUnityPackTask(project)
 
-        ProjectType type = new ProjectType(project)
-        if (type.isRootProject) {
+        if (project == project.rootProject) {
             configureSetupTask(project)
             configureReleaseLifecycle(project)
             configureGithubPublishTask(project)
@@ -411,9 +408,8 @@ class ReleasePlugin implements Plugin<Project> {
      */
     protected static void applyNebularRelease(Project project) {
         project.pluginManager.apply(nebula.plugin.release.ReleasePlugin)
-        ProjectType type = new ProjectType(project)
 
-        if (type.isRootProject) {
+        if (project == project.rootProject) {
             ReleasePluginExtension releaseExtension = project.extensions.findByType(ReleasePluginExtension)
 
             releaseExtension.with {


### PR DESCRIPTION
## Description

As a preparation for the `1.x` release of this package I updated the underlying dependency to Nebular Release.

## Changes

![UPDATE] nebular release plugin to `6.+`


[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
