### PR TITLE
Remove mustache dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,6 @@ dependencies {
 
     compile 'com.netflix.nebula:nebula-release-plugin:6.+'
     compile 'org.ajoberstar:gradle-git:1.7.+'
-    compile 'com.github.spullara.mustache.java:compiler:0.8.18'
     compile 'cz.malohlava:visteg:1.0.+'
     compile 'gradle.plugin.net.wooga.gradle:atlas-paket:1.+'
     compile 'gradle.plugin.net.wooga.gradle:atlas-github:1.+'


### PR DESCRIPTION
## Description

While checking the reason for failing android plugin execution together with the new release plugin I found that we still have this unused dependency.

## Changes

![REMOVE] unused dependency `om.github.spullara.mustache.java:compiler`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
