### PR TITLE
Fix semver v2 snapshot strategy

### DIFF
--- a/src/main/groovy/wooga/gradle/release/version/semver2/VersionStrategies.groovy
+++ b/src/main/groovy/wooga/gradle/release/version/semver2/VersionStrategies.groovy
@@ -201,7 +201,7 @@ final class VersionStrategies {
      */
     static final SemVerStrategy SNAPSHOT = DEFAULT.copyWith(
             name: 'snapshot',
-            stages: ['ci', 'snapshot'] as SortedSet,
+            stages: ['ci', 'snapshot', 'SNAPSHOT'] as SortedSet,
             allowDirtyRepo: true,
             createTag: false,
             preReleaseStrategy: all(PreRelease.STAGE_BRANCH_NAME, Strategies.PreRelease.COUNT_COMMITS_SINCE_ANY)


### PR DESCRIPTION
## Description

The new semver v2 snapshot strategy doesn't get applied when the current stage == `SNAPSHOT`. Since we want to have backwards compatibility to switch from v1 to v2 this must be fixed

## Changes

* ![FIX] semver v2 snapshot strategy

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
