### PR TITLE
Fix version precedence check for snapshot (ci) builds

### DIFF
--- a/src/main/groovy/wooga/gradle/release/version/semver2/VersionStrategies.groovy
+++ b/src/main/groovy/wooga/gradle/release/version/semver2/VersionStrategies.groovy
@@ -204,6 +204,7 @@ final class VersionStrategies {
             stages: ['ci', 'snapshot', 'SNAPSHOT'] as SortedSet,
             allowDirtyRepo: true,
             createTag: false,
-            preReleaseStrategy: all(PreRelease.STAGE_BRANCH_NAME, Strategies.PreRelease.COUNT_COMMITS_SINCE_ANY)
+            preReleaseStrategy: all(PreRelease.STAGE_BRANCH_NAME, Strategies.PreRelease.COUNT_COMMITS_SINCE_ANY),
+            enforcePrecedence: false
     )
 }

--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -429,6 +429,7 @@ class ReleasePluginSpec extends ProjectSpec {
 
         _                 | 2        | "ci"         | _       | "1.x"           | "1.1.0-branch.1.x.2"
         _                 | 4        | "ci"         | _       | "1.0.x"         | "1.0.1-branch.1.0.x.4"
+        '2.0.0-rc.2'      | 0        | "ci"         | _       | "release/2.x"   | "2.0.0-branch.release.2.x.0"
 
         _                 | 1        | "snapshot"   | _       | "master"        | "1.1.0-master.1"
         _                 | 2        | "snapshot"   | "major" | "master"        | "2.0.0-master.2"


### PR DESCRIPTION
## Description

The new `semver 2.0` snapshot strategy enforces version precedence due to a configuration error. This is a clear bug because snapshot builds are designed to be outside the version order for `rc` or `final` builds. So how can this bug show itself. The only valid way at the moment to trigger this bug is to build a prerelease build (`rc`) and then a snapshot version with the same base version. This can happen in `release/2.x` branches. A snapshot build should have no direct connections to any pre or final release.

**gradle output**
```
> Inferred version (2.0.0-branch.release.2.x.0) cannot be lower than nearest (2.0.0-rc.1). Required by selected strategy.
```

This patch simply configures the snapshot strategy not to enforce version precedence (the old v1 did this as well).

## Changes

![FIX] semver `2.0` snasphot version prcedence check

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
