### PR TITLE
Allow dirty repo in all semver 2.0 strategies

### DIFF
--- a/src/main/groovy/wooga/gradle/release/version/semver2/VersionStrategies.groovy
+++ b/src/main/groovy/wooga/gradle/release/version/semver2/VersionStrategies.groovy
@@ -78,7 +78,7 @@ final class VersionStrategies {
     static final SemVerStrategy DEFAULT = new SemVerStrategy(
             name: '',
             stages: [] as SortedSet,
-            allowDirtyRepo: false,
+            allowDirtyRepo: true,
             normalStrategy: scopes,
             preReleaseStrategy: Strategies.PreRelease.NONE,
             buildMetadataStrategy: BuildMetadata.NONE,
@@ -202,7 +202,6 @@ final class VersionStrategies {
     static final SemVerStrategy SNAPSHOT = DEFAULT.copyWith(
             name: 'snapshot',
             stages: ['ci', 'snapshot', 'SNAPSHOT'] as SortedSet,
-            allowDirtyRepo: true,
             createTag: false,
             preReleaseStrategy: all(PreRelease.STAGE_BRANCH_NAME, Strategies.PreRelease.COUNT_COMMITS_SINCE_ANY),
             enforcePrecedence: false


### PR DESCRIPTION
## Description

This patch sets the `allowDirtyRepo` flag for all semver 2.0 strategies to `true`. This check makes more problems than it solved in reality. Another patch might add a warning instead of a hard fail.

## Changes

![CHANGE] set `allowDirtyRepo` to true for all semver 2.0 strategies

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
