### PR TITLE
Pin version of com.wooga.gradle:gradle-commons-test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 
     testImplementation 'gradle.plugin.net.wooga.gradle:atlas-unity:2.0.0-rc.3'
     testImplementation 'gradle.plugin.net.wooga.gradle:atlas-wdk-unity:2.0.0-rc.3'
-    testImplementation 'com.wooga.gradle:gradle-commons-test:(0, 1]'
+    testImplementation 'com.wooga.gradle:gradle-commons-test:0.1.0'
 
     implementation group: 'org.kohsuke', name: 'github-api', version: '1.130'
     implementation 'org.ajoberstar.grgit:grgit-core:(4.1,5]'


### PR DESCRIPTION
## Description

The 0. version range should never be declared with a range since any new minor release can contain breaking changes. We need to pin to a compatible version and update
manually or through use of dependabot.

## Changes

* ![FIX] pin unstable version of `com.wooga.gradle:gradle-commons-test`


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
