### PR TITLE
Fix wrong branch for release tag

### DIFF
--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -235,6 +235,7 @@ class ReleasePlugin implements Plugin<Project> {
         githubPublishTask.dependsOn(archives)
         githubPublishTask.tagName.set("v${project.version}")
         githubPublishTask.releaseName.set(project.version.toString())
+        githubPublishTask.targetCommitish.set(project.extensions.grgit.branch.current.name as String)
         // Gradle defaults to 'release' for the project status, as seen here:
         // https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getStatus--
         githubPublishTask.prerelease.set(project.provider { project.status != 'final' && project.status != 'release' })


### PR DESCRIPTION
## Description
Release tags for the github releases are now generated on current branch, instead of always using master HEAD as base.

## Changes
* ![FIX] release tags are now generated on current branch

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
