### PR TITLE
Adds the preflight release_stage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,9 @@ dependencies {
     implementation group: 'org.kohsuke', name: 'github-api', version: '1.135'
     implementation 'org.ajoberstar.grgit:grgit-core:(4.1,5]'
     implementation 'org.ajoberstar.grgit:grgit-gradle:(4.1,5]'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:1+'
+    implementation 'com.wooga.gradle:gradle-commons:[1,2)'
+
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:(1.2+, 2]'
     implementation 'gradle.plugin.net.wooga.gradle:atlas-paket:(2, 3]'
     implementation 'gradle.plugin.net.wooga.gradle:atlas-github:(2, 3]'
     implementation 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:(1, 2]'

--- a/src/integrationTest/groovy/wooga/gradle/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/ReleasePluginIntegrationSpec.groovy
@@ -200,21 +200,21 @@ class ReleasePluginIntegrationSpec extends IntegrationSpec {
         aSubDir2.mkdirs()
 
         def filesToDelete = [
-                createFile("file.cs.meta", assetsDir),
-                createFile("file.json.meta", assetsDir),
-                createFile(".meta", assetsDir),
-                createFile("test.cs", assetsDir),
-                createFile("test.json", assetsDir),
-                createFile("test.cs", aSubDir),
-                createFile("test.json", aSubDir),
+            createFile("file.cs.meta", assetsDir),
+            createFile("file.json.meta", assetsDir),
+            createFile(".meta", assetsDir),
+            createFile("test.cs", assetsDir),
+            createFile("test.json", assetsDir),
+            createFile("test.cs", aSubDir),
+            createFile("test.json", aSubDir),
         ]
 
         def filesToKeep = [
-                createFile("test.dll.meta", assetsDir),
-                createFile("file.cs.meta", aSubDir2),
-                createFile("file.json.meta", aSubDir2),
-                createFile(".meta", aSubDir2),
-                createFile("test.dll.meta", aSubDir),
+            createFile("test.dll.meta", assetsDir),
+            createFile("file.cs.meta", aSubDir2),
+            createFile("file.json.meta", aSubDir2),
+            createFile(".meta", aSubDir2),
+            createFile("test.dll.meta", aSubDir),
         ]
 
         and: "a buildfile with release plugin applied"
@@ -263,20 +263,20 @@ class ReleasePluginIntegrationSpec extends IntegrationSpec {
         def filesToDelete = []
 
         def filesToKeep = [
-                createFile("test.meta", assetsDir),
-                createFile(".meta", assetsDir),
-                createFile("test.meta", aSubDir),
-                createFile(".meta", aSubDir),
-                createFile("test.dll.meta", assetsDir),
-                createFile("test.cs", assetsDir),
-                createFile("test.json", assetsDir),
-                createFile("test.cs", aSubDir),
-                createFile("test.json", aSubDir),
-                createFile("test.so.meta", assetsDir),
-                createFile("test.dll.meta", aSubDir),
-                createFile("test.so.meta", aSubDir),
-                createFile("test.meta", unitySub),
-                createFile(".meta", unitySub)]
+            createFile("test.meta", assetsDir),
+            createFile(".meta", assetsDir),
+            createFile("test.meta", aSubDir),
+            createFile(".meta", aSubDir),
+            createFile("test.dll.meta", assetsDir),
+            createFile("test.cs", assetsDir),
+            createFile("test.json", assetsDir),
+            createFile("test.cs", aSubDir),
+            createFile("test.json", aSubDir),
+            createFile("test.so.meta", assetsDir),
+            createFile("test.dll.meta", aSubDir),
+            createFile("test.so.meta", aSubDir),
+            createFile("test.meta", unitySub),
+            createFile(".meta", unitySub)]
 
         and: "a buildfile with release plugin applied"
         buildFile << """
@@ -436,10 +436,11 @@ class ReleasePluginIntegrationSpec extends IntegrationSpec {
         query.matches(result, isPrerelease)
 
         where:
-        status    | isPrerelease
-        "final"   | false
-        "release" | false
-        "rc"      | true
+        status      | isPrerelease
+        "final"     | false
+        "release"   | false
+        "rc"        | true
+        "preflight" | true
 
         expectedMessage = isPrerelease ? "set" : "not set"
     }

--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -31,7 +31,8 @@ import wooga.gradle.github.publish.GithubPublishPlugin
 import wooga.gradle.paket.PaketPlugin
 import wooga.gradle.paket.pack.tasks.PaketPack
 import wooga.gradle.paket.unity.PaketUnityPlugin
-
+import wooga.gradle.version.VersionPluginExtension
+import wooga.gradle.version.VersionScheme
 
 class ReleasePluginSpec extends ProjectSpec {
     public static final String PLUGIN_NAME = 'net.wooga.release'
@@ -697,6 +698,20 @@ class ReleasePluginSpec extends ProjectSpec {
 
         satisfiedMessage = satisfied ? "satisfied" : "not satisfied"
         repoStatus = repositoryName ? "is set" : "is not set"
+    }
+
+    @Unroll
+    def "verifies that the default version scheme is #defaultScheme"(){
+
+        when: "a gradle project with plugin applied and evaluated"
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        VersionPluginExtension versionExtension = project.extensions.findByType(VersionPluginExtension)
+        versionExtension.versionScheme.get() == defaultScheme
+
+        where:
+        defaultScheme = VersionScheme.semver
     }
 
 }


### PR DESCRIPTION
## Description

Adds support for the preflight release stage.

## Changes
* ![ADD] Support for the newer `preflight` release stage, as a task
* ![UPDATE] `atlas-version` to `1.1+`, as it includes the newer release stage and wdk strategy.
 
[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
