### PR TITLE
Add preflight publish task

### DIFF
--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -76,6 +76,7 @@ class ReleasePlugin implements Plugin<Project> {
     public static final String SETUP_TASK = "setup"
 
     public static final String SNAPSHOT_TASK_NAME = "snapshot"
+    public static final String PREFLIGHT_TASK_NAME = "preflight"
     public static final String RC_TASK_NAME = "rc"
     public static final String FINAL_TASK_NAME = "final"
 
@@ -149,11 +150,12 @@ class ReleasePlugin implements Plugin<Project> {
         // which was deprecated in favor of our own solution. These tasks have no action, they instead
         // work by mapping the 'release.stage' property.
         // For example, invoking the `final` task will have the `release.stage` property set to `final`
+        Task preflightTask = project.tasks.create(PREFLIGHT_TASK_NAME)
         Task finalTask = project.tasks.create(FINAL_TASK_NAME)
         Task rcTask = project.tasks.create(RC_TASK_NAME)
         Task snapshotTask = project.tasks.create(SNAPSHOT_TASK_NAME)
 
-        [snapshotTask, rcTask, finalTask].each {
+        [snapshotTask, preflightTask, rcTask, finalTask].each {
             it.dependsOn publishTask
         }
 


### PR DESCRIPTION
## Description

Add  an empty `preflight` task for compatibility reasons with the calling jenkins pipeline.

## Changes
* ![ADD] `prefligh` publish task

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
