### PR TITLE
Add snyk monitoring [ATLAS-702]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,8 @@
 withCredentials([usernamePassword(credentialsId: 'github_integration', passwordVariable: 'githubPassword', usernameVariable: 'githubUser'),
                  usernamePassword(credentialsId: 'github_integration_2', passwordVariable: 'githubPassword2', usernameVariable: 'githubUser2'),
                  string(credentialsId: 'atlas_release_coveralls_token', variable: 'coveralls_token'),
-                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token')]) {
+                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
+                 string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
 
     def testEnvironment = [ 'macos':
                                [

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,10 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.3'
+    id 'net.wooga.plugins' version '2.3.0'
+    id 'net.wooga.snyk' version '0.10.0'
+    id "net.wooga.snyk-gradle-plugin" version "0.2.0"
+    id "net.wooga.cve-dependency-resolution" version "0.4.0"
 }
 
 group 'net.wooga.gradle'
@@ -40,6 +43,10 @@ github {
     repositoryName = "wooga/atlas-release"
 }
 
+cveHandler {
+    configurations("compileClasspath", "runtimeClasspath", "testCompileClasspath", "testRuntimeClasspath", "integrationTestCompileClasspath", "integrationTestRuntimeClasspath")
+}
+
 repositories {
     mavenCentral()
     gradlePluginPortal()
@@ -49,33 +56,23 @@ repositories {
     }
 }
 
-configurations.all {
-    resolutionStrategy {
-        force 'org.codehaus.groovy:groovy-all:2.5.12'
-        force 'org.codehaus.groovy:groovy-macro:2.5.12'
-        force 'org.codehaus.groovy:groovy-nio:2.5.12'
-        force 'org.codehaus.groovy:groovy-sql:2.5.12'
-        force 'org.codehaus.groovy:groovy-xml:2.5.12'
-    }
-}
-
 dependencies {
     testImplementation('org.jfrog.artifactory.client:artifactory-java-client-services:+') {
         exclude module: 'logback-classic'
     }
 
-    testImplementation 'gradle.plugin.net.wooga.gradle:atlas-unity:2.3.0'
-    testImplementation 'gradle.plugin.net.wooga.gradle:atlas-wdk-unity:2.1.1'
-    testImplementation 'com.wooga.gradle:gradle-commons-test:(1,2]'
+    testImplementation 'gradle.plugin.net.wooga.gradle:atlas-unity:[2.3.0,3['
+    testImplementation 'gradle.plugin.net.wooga.gradle:atlas-wdk-unity:[2.1.1,3['
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1,2['
 
     implementation group: 'org.kohsuke', name: 'github-api', version: '1.135'
-    implementation 'org.ajoberstar.grgit:grgit-core:(4.1,5]'
-    implementation 'org.ajoberstar.grgit:grgit-gradle:(4.1,5]'
-    implementation 'com.wooga.gradle:gradle-commons:[1,2)'
+    implementation 'org.ajoberstar.grgit:grgit-core:[4.1.1,5['
+    implementation 'org.ajoberstar.grgit:grgit-gradle:[4.1.1,5['
+    implementation 'com.wooga.gradle:gradle-commons:[1,2['
 
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:(1.2+, 2]'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-paket:(2, 3]'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-github:(2, 3]'
-    implementation 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:(1, 2]'
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-version:[1.3,2['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-paket:[2,3['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-github:[2.1,3['
+    implementation 'gradle.plugin.net.wooga.gradle:atlas-GithubReleaseNotes:[1.1,2['
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -21,5 +21,11 @@ include 'shared'
 include 'api'
 include 'services:webservice'
 */
+pluginManagement {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+}
 
 rootProject.name = 'atlas-release'


### PR DESCRIPTION
## Decription

This patch adds snyk monitoring to the build pipeline. It will hook itself into the check and publish stages.

The patch also sets a dependency helper plugin net.wooga.cve-dependency-resolution which applies overrides for dependencies with know fixes for security issues.

## Changes

* ![ADD] `snyk` monitoring
* ![ADD] `net.wooga.snyk-wdk-java` snyk convention plugin
* ![ADD] `net.wogoa.cve-dependency-resolution` plugin

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
