### PR TITLE
Root-Level Project Support + WDK-Release tasks collision fix [ATLAS-1451]

### DIFF
--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -150,10 +150,10 @@ class ReleasePlugin implements Plugin<Project> {
         // which was deprecated in favor of our own solution. These tasks have no action, they instead
         // work by mapping the 'release.stage' property.
         // For example, invoking the `final` task will have the `release.stage` property set to `final`
-        Task preflightTask = project.tasks.create(PREFLIGHT_TASK_NAME)
-        Task finalTask = project.tasks.create(FINAL_TASK_NAME)
-        Task rcTask = project.tasks.create(RC_TASK_NAME)
-        Task snapshotTask = project.tasks.create(SNAPSHOT_TASK_NAME)
+        Task preflightTask = project.tasks.maybeCreate(PREFLIGHT_TASK_NAME)
+        Task finalTask = project.tasks.maybeCreate(FINAL_TASK_NAME)
+        Task rcTask = project.tasks.maybeCreate(RC_TASK_NAME)
+        Task snapshotTask = project.tasks.maybeCreate(SNAPSHOT_TASK_NAME)
 
         [snapshotTask, preflightTask, rcTask, finalTask].each {
             it.dependsOn publishTask
@@ -339,7 +339,7 @@ class ReleasePlugin implements Plugin<Project> {
         DependencyHandler dependencies = project.dependencies
         def rootPaketUnityInstall = project.rootProject.tasks[PaketUnityPlugin.INSTALL_TASK_NAME]
         def rootPaketUnwrapUPM = project.rootProject.tasks[PaketUnityPlugin.UNWRAP_UPM_TASK_NAME]
-        project.subprojects { Project sub ->
+        project.allprojects { Project sub ->
             sub.pluginManager.withPlugin("net.wooga.unity", new Action<AppliedPlugin>() {
                 @Override
                 void execute(AppliedPlugin unityPlugin) {

--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.Task
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.internal.tasks.TaskExecutionOutcome
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.publish.plugins.PublishingPlugin
 import org.gradle.api.specs.Spec
 import org.gradle.cache.internal.VersionStrategy
 import spock.lang.Ignore
@@ -90,6 +91,26 @@ class ReleasePluginSpec extends ProjectSpec {
         "githubPublish" | GithubPublishPlugin
         "paket"         | PaketPlugin
         "paket-unity"   | PaketUnityPlugin
+    }
+
+    def 'Supports adding wdk-unity-release first'() {
+        given:
+        assert !project.plugins.hasPlugin(PLUGIN_NAME)
+        and:
+        project.tasks.register(ReleasePlugin.SNAPSHOT_TASK_NAME) {}
+        project.tasks.register(ReleasePlugin.RC_TASK_NAME) {}
+        project.tasks.register(ReleasePlugin.PREFLIGHT_TASK_NAME) {}
+        project.tasks.register(ReleasePlugin.FINAL_TASK_NAME) {}
+
+        when:
+        project.plugins.apply(PLUGIN_NAME)
+
+        then:
+        project.plugins.hasPlugin(PLUGIN_NAME)
+        project.tasks.findByName(ReleasePlugin.SNAPSHOT_TASK_NAME).dependsOn.collect{it.name}.contains(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+        project.tasks.findByName(ReleasePlugin.RC_TASK_NAME).dependsOn.collect{it.name}.contains(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+        project.tasks.findByName(ReleasePlugin.PREFLIGHT_TASK_NAME).dependsOn.collect{it.name}.contains(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
+        project.tasks.findByName(ReleasePlugin.FINAL_TASK_NAME).dependsOn.collect{it.name}.contains(PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME)
     }
 
     def findStrategyByName(List<VersionStrategy> strategies, name) {


### PR DESCRIPTION
## Description

[ATLAS-1451](https://woogagmbh.atlassian.net/browse/ATLAS-1451)

Make sure release plugin can be added after wdk-release plugin by not creating the same tasks.

Add support for the root-level folder structure for configuring the unity package.

## Changes
* ![IMPROVE] Optionally add tasks to support co-existence with wdk-release plugin
* ![CHANGE] Add support for the root-level folder structure for configuring the unity package

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"


[ATLAS-1451]: https://woogagmbh.atlassian.net/browse/ATLAS-1451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ