### PR TITLE
Make plugin compatible with net.wooga.version 3.x

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/release/ReleasePluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/release/ReleasePluginIntegrationSpec.groovy
@@ -420,10 +420,10 @@ class ReleasePluginIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec
 
         where:
         tagVersion       | versionCode
-        '1.1.0'          | 10101
+        '1.1.0'          | 10200
         '2.10.99'        | 21100
-        '0.3.0'          | 301
-        '12.34.200'      | 123601
+        '0.3.0'          | 400
+        '12.34.200'      | 123500
         '1.1.0-rc0001'   | 10100
         '2.10.99-branch' | 21099
         '0.3.0-a0000'    | 300
@@ -454,10 +454,10 @@ class ReleasePluginIntegrationSpec extends com.wooga.gradle.test.IntegrationSpec
 
         where:
         tagVersion       | versionCode
-        '1.1.0'          | 10101
+        '1.1.0'          | 10200
         '2.10.99'        | 21100
-        '0.3.0'          | 301
-        '12.34.200'      | 123601
+        '0.3.0'          | 400
+        '12.34.200'      | 123500
         '1.1.0-rc0001'   | 10100
         '2.10.99-branch' | 21099
         '0.3.0-a0000'    | 300

--- a/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/release/ReleasePlugin.groovy
@@ -46,12 +46,11 @@ import wooga.gradle.release.internal.DefaultAtlasReleasePluginExtension
 import wooga.gradle.release.releasenotes.ReleaseNotesBodyStrategy
 import wooga.gradle.githubReleaseNotes.GithubReleaseNotesPlugin
 import wooga.gradle.release.utils.ProjectPropertyValueTaskSpec
-
-//import wooga.gradle.releaseNotesGenerator.ReleaseNotesGeneratorPlugin
-//import wooga.gradle.releaseNotesGenerator.utils.ReleaseBodyStrategy
+import wooga.gradle.version.ReleaseStage
 import wooga.gradle.version.VersionPlugin
 import wooga.gradle.version.VersionPluginExtension
 import wooga.gradle.version.VersionScheme
+import wooga.gradle.version.VersionSchemes
 
 /**
  * A Wooga internal plugin to develop and publish Unity library packages.
@@ -84,7 +83,6 @@ class ReleasePlugin implements Plugin<Project> {
     public static final String RELEASE_NOTES_BODY_TASK_NAME = "generateReleaseNotesBody"
 
     static final String ARCHIVES_CONFIGURATION = "archives"
-    static final VersionScheme defaultVersionScheme = VersionScheme.semver
 
     @Override
     void apply(Project project) {
@@ -239,8 +237,9 @@ class ReleasePlugin implements Plugin<Project> {
         // Gradle defaults to 'release' for the project status, as seen here:
         // https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#getStatus--
         //keeping project.status as a fallback to avoid potential breaking change
+        def isFinal = versionExt.releaseStage.map {it == ReleaseStage.Final }
         githubPublishTask.prerelease.set(
-                versionExt.isFinal.map { !it as boolean}
+                isFinal.map { !it as boolean}
                         .orElse(project.provider {project.status != 'final' && project.status != 'release'})
         )
 

--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -37,6 +37,7 @@ import wooga.gradle.paket.pack.tasks.PaketPack
 import wooga.gradle.paket.unity.PaketUnityPlugin
 import wooga.gradle.version.VersionPluginExtension
 import wooga.gradle.version.VersionScheme
+import wooga.gradle.version.VersionSchemes
 
 class ReleasePluginSpec extends ProjectSpec {
     public static final String PLUGIN_NAME = 'net.wooga.release'
@@ -735,7 +736,7 @@ class ReleasePluginSpec extends ProjectSpec {
         versionExtension.versionScheme.get() == defaultScheme
 
         where:
-        defaultScheme = VersionScheme.semver
+        defaultScheme = VersionSchemes.semver
     }
 
     @Unroll

--- a/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/release/ReleasePluginSpec.groovy
@@ -257,37 +257,37 @@ class ReleasePluginSpec extends ProjectSpec {
 
         where:
         nearestAny      | distance | stage      | scope   | branchName      | expectedVersion
-        _               | 1        | "snapshot" | _       | "master"        | "1.0.1-master00001"
+        _               | 1        | "snapshot" | _       | "master"        | "1.1.0-master00001"
         _               | 2        | "snapshot" | "major" | "master"        | "2.0.0-master00002"
         _               | 3        | "snapshot" | "minor" | "master"        | "1.1.0-master00003"
         _               | 4        | "snapshot" | "patch" | "master"        | "1.0.1-master00004"
 
-        _               | 1        | "snapshot" | _       | "develop"       | "1.0.1-branchDevelop00001"
+        _               | 1        | "snapshot" | _       | "develop"       | "1.1.0-branchDevelop00001"
         _               | 2        | "snapshot" | "major" | "develop"       | "2.0.0-branchDevelop00002"
         _               | 3        | "snapshot" | "minor" | "develop"       | "1.1.0-branchDevelop00003"
         _               | 4        | "snapshot" | "patch" | "develop"       | "1.0.1-branchDevelop00004"
 
-        _               | 1        | "snapshot" | _       | "feature/check" | "1.0.1-branchFeatureCheck00001"
-        _               | 2        | "snapshot" | _       | "hotfix/check"  | "1.0.1-branchHotfixCheck00002"
-        _               | 3        | "snapshot" | _       | "fix/check"     | "1.0.1-branchFixCheck00003"
-        _               | 4        | "snapshot" | _       | "feature-check" | "1.0.1-branchFeatureCheck00004"
-        _               | 5        | "snapshot" | _       | "hotfix-check"  | "1.0.1-branchHotfixCheck00005"
-        _               | 6        | "snapshot" | _       | "fix-check"     | "1.0.1-branchFixCheck00006"
-        _               | 7        | "snapshot" | _       | "PR-22"         | "1.0.1-branchPRTwoTwo00007"
+        _               | 1        | "snapshot" | _       | "feature/check" | "1.1.0-branchFeatureCheck00001"
+        _               | 2        | "snapshot" | _       | "hotfix/check"  | "1.1.0-branchHotfixCheck00002"
+        _               | 3        | "snapshot" | _       | "fix/check"     | "1.1.0-branchFixCheck00003"
+        _               | 4        | "snapshot" | _       | "feature-check" | "1.1.0-branchFeatureCheck00004"
+        _               | 5        | "snapshot" | _       | "hotfix-check"  | "1.1.0-branchHotfixCheck00005"
+        _               | 6        | "snapshot" | _       | "fix-check"     | "1.1.0-branchFixCheck00006"
+        _               | 7        | "snapshot" | _       | "PR-22"         | "1.1.0-branchPRTwoTwo00007"
         // TODO: Not supported by the atlas-version plugin currently
 //        _               | 8        | "snapshot" | _       | "fix/a_-bug"    | "1.0.1-branchFixABug00008"
 //        _               | 9        | "snapshot" | _       | "fix/-_.bug"    | "1.0.1-branchFixDotbug00009"
 //        _               | 10       | "snapshot" | _       | "fix/-.-.-bug"  | "1.0.1-branchFixDotDotBug00010"
 
-        _               | 1        | "snapshot" | _       | "release/1.x"   | "1.0.1-branchReleaseOneDotx00001"
-        _               | 2        | "snapshot" | _       | "release-1.x"   | "1.0.1-branchReleaseOneDotx00002"
+        _               | 1        | "snapshot" | _       | "release/1.x"   | "1.1.0-branchReleaseOneDotx00001"
+        _               | 2        | "snapshot" | _       | "release-1.x"   | "1.1.0-branchReleaseOneDotx00002"
         _               | 3        | "snapshot" | _       | "release/1.0.x" | "1.0.1-branchReleaseOneDotZeroDotx00003"
         _               | 4        | "snapshot" | _       | "release-1.0.x" | "1.0.1-branchReleaseOneDotZeroDotx00004"
 
-        _               | 2        | "snapshot" | _       | "1.x"           | "1.0.1-branchOneDotx00002"
+        _               | 2        | "snapshot" | _       | "1.x"           | "1.1.0-branchOneDotx00002"
         _               | 4        | "snapshot" | _       | "1.0.x"         | "1.0.1-branchOneDotZeroDotx00004"
 
-        _               | 1        | "rc"       | _       | "master"        | "1.0.1-rc00001"
+        _               | 1        | "rc"       | _       | "master"        | "1.1.0-rc00001"
         _               | 2        | "rc"       | "major" | "master"        | "2.0.0-rc00001"
         _               | 3        | "rc"       | "minor" | "master"        | "1.1.0-rc00001"
         _               | 4        | "rc"       | "patch" | "master"        | "1.0.1-rc00001"
@@ -295,12 +295,12 @@ class ReleasePluginSpec extends ProjectSpec {
         '1.1.0-rc00001' | 1        | "rc"       | _       | "master"        | "1.1.0-rc00002"
         '1.1.0-rc00002' | 1        | "rc"       | _       | "master"        | "1.1.0-rc00003"
 
-        _               | 1        | "rc"       | _       | "release/1.x"   | "1.0.1-rc00001"
-        _               | 2        | "rc"       | _       | "release-1.x"   | "1.0.1-rc00001"
+        _               | 1        | "rc"       | _       | "release/1.x"   | "1.1.0-rc00001"
+        _               | 2        | "rc"       | _       | "release-1.x"   | "1.1.0-rc00001"
         _               | 3        | "rc"       | _       | "release/1.0.x" | "1.0.1-rc00001"
         _               | 4        | "rc"       | _       | "release-1.0.x" | "1.0.1-rc00001"
 
-        _               | 1        | "rc"       | _       | "1.x"           | "1.0.1-rc00001"
+        _               | 1        | "rc"       | _       | "1.x"           | "1.1.0-rc00001"
         _               | 3        | "rc"       | _       | "1.0.x"         | "1.0.1-rc00001"
 
         "1.1.0-rc00001" | 1        | "rc"       | _       | "release/1.x"   | "1.1.0-rc00002"
@@ -311,18 +311,18 @@ class ReleasePluginSpec extends ProjectSpec {
         "1.1.0-rc00001" | 1        | "rc"       | _       | "1.x"           | "1.1.0-rc00002"
         "1.0.1-rc00001" | 3        | "rc"       | _       | "1.0.x"         | "1.0.1-rc00002"
 
-        _               | 1        | "final"    | _       | "master"        | "1.0.1"
+        _               | 1        | "final"    | _       | "master"        | "1.1.0"
         _               | 2        | "final"    | "major" | "master"        | "2.0.0"
         _               | 3        | "final"    | "minor" | "master"        | "1.1.0"
         _               | 4        | "final"    | "patch" | "master"        | "1.0.1"
 
-        _               | 1        | "final"    | _       | "release/1.x"   | "1.0.1"
-        _               | 1        | "final"    | _       | "release/1.x"   | "1.0.1"
-        _               | 2        | "final"    | _       | "release-1.x"   | "1.0.1"
+        _               | 1        | "final"    | _       | "release/1.x"   | "1.1.0"
+        _               | 1        | "final"    | _       | "release/1.x"   | "1.1.0"
+        _               | 2        | "final"    | _       | "release-1.x"   | "1.1.0"
         _               | 3        | "final"    | _       | "release/1.0.x" | "1.0.1"
         _               | 4        | "final"    | _       | "release-1.0.x" | "1.0.1"
 
-        _               | 1        | "final"    | _       | "1.x"           | "1.0.1"
+        _               | 1        | "final"    | _       | "1.x"           | "1.1.0"
         _               | 3        | "final"    | _       | "1.0.x"         | "1.0.1"
 
         nearestNormal = '1.0.0'
@@ -551,12 +551,12 @@ class ReleasePluginSpec extends ProjectSpec {
 
         where:
         branchName          | expectedVersion
-        "master"            | "1.0.1-master00001"
-        "with/slash"        | "1.0.1-branchWithSlash00001"
-        "numbers0123456789" | "1.0.1-branchNumbersZeroOneTwoThreeFourFiveSixSevenEightNine00001"
-        "with/slash"        | "1.0.1-branchWithSlash00001"
-        "with_underscore"   | "1.0.1-branchWithUnderscore00001"
-        "with-dash"         | "1.0.1-branchWithDash00001"
+        "master"            | "1.1.0-master00001"
+        "with/slash"        | "1.1.0-branchWithSlash00001"
+        "numbers0123456789" | "1.1.0-branchNumbersZeroOneTwoThreeFourFiveSixSevenEightNine00001"
+        "with/slash"        | "1.1.0-branchWithSlash00001"
+        "with_underscore"   | "1.1.0-branchWithUnderscore00001"
+        "with-dash"         | "1.1.0-branchWithDash00001"
     }
 
     def createFile(String fileName, File directory) {


### PR DESCRIPTION
## Description
Small changes to make the plugin compatible with next major of net.wooga.version. 

* Remove unused value which applied `VersionScheme` instead of `VersionSchemes`
* remap `isFinal` to `releaseScope == ReleaseScope.Final`.

## Changes
* ![FIX] broken apply due to new `net.wooga.version` major




[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
